### PR TITLE
Add documentation site

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -147,6 +147,7 @@ jobs:
 
   build-docs:
     runs-on: ubuntu-latest
+    if: github.event_name == 'push'
     steps:
       - name: Check out code
         uses: actions/checkout@v2
@@ -154,21 +155,18 @@ jobs:
       - name: Build Docs
         run: docker-compose run --rm mkdocs build --strict
 
-      # publish to a dev directory & don't clean anything
-      - name: Publish (dev)
-        uses: JamesIves/github-pages-deploy-action@releases/v3
-        if: github.event_name == 'push' && github.ref != 'refs/heads/main'
+      # upload artifact for dev build
+      - name: Upload coverage results artifact
+        if: github.ref != 'refs/heads/main'
+        uses: actions/upload-artifact@v2
         with:
-          ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
-          BRANCH: gh-pages
-          FOLDER: site
-          TARGET_FOLDER: _dev/
-          CLEAN: false
+          name: docs-site
+          path: site/
 
       # publish to the root and clean everything
       - name: Publish (prod)
         uses: JamesIves/github-pages-deploy-action@releases/v3
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main'
         with:
           ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
           BRANCH: gh-pages

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -180,14 +180,3 @@ jobs:
           ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
           BRANCH: gh-pages
           FOLDER: site
-
-      # publish to a dev directory & don't clean anything
-      - name: Publish (dev)
-        uses: JamesIves/github-pages-deploy-action@releases/v3
-        with:
-          ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
-          BRANCH: gh-pages
-          FOLDER: site
-          TARGET_FOLDER: _dev/
-          CLEAN: false
-

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -154,10 +154,6 @@ jobs:
       - name: Build Docs
         run: docker-compose run --rm mkdocs build --strict
 
-      - name: Extract branch name
-        shell: bash
-        run: echo "BRANCH_NAME=${GITHUB_REF#refs/heads/} | sed 's/\//_/g')" >> $GITHUB_ENV
-
       # publish to a dev directory & don't clean anything
       - name: Publish (dev)
         uses: JamesIves/github-pages-deploy-action@releases/v3
@@ -166,8 +162,7 @@ jobs:
           ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
           BRANCH: gh-pages
           FOLDER: site
-          TARGET_FOLDER: _dev/${{ env.BRANCH_NAME }}
-          CLEAN: false
+          TARGET_FOLDER: _dev/
 
       # publish to the root and clean everything
       - name: Publish (prod)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -154,29 +154,23 @@ jobs:
       - name: Build Docs
         run: docker-compose run --rm mkdocs build --strict
 
-#      # publish to a dev directory & don't clean anything
-#      - name: Publish (dev)
-#        uses: JamesIves/github-pages-deploy-action@releases/v3
-#        if: github.event_name == 'push' && github.ref != 'refs/heads/main'
-#        with:
-#          ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
-#          BRANCH: gh-pages
-#          FOLDER: site
-#          TARGET_FOLDER: _dev/
-#
-#      # publish to the root and clean everything
-#      - name: Publish (prod)
-#        uses: JamesIves/github-pages-deploy-action@releases/v3
-#        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-#        with:
-#          ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
-#          BRANCH: gh-pages
-#          FOLDER: site
-
-      # publish to the root and clean everything
-      - name: Publish (prod)
+      # publish to a dev directory & don't clean anything
+      - name: Publish (dev)
         uses: JamesIves/github-pages-deploy-action@releases/v3
+        if: github.event_name == 'push' && github.ref != 'refs/heads/main'
         with:
           ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
           BRANCH: gh-pages
           FOLDER: site
+          TARGET_FOLDER: _dev/
+          CLEAN: false
+
+      # publish to the root and clean everything
+      - name: Publish (prod)
+        uses: JamesIves/github-pages-deploy-action@releases/v3
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        with:
+          ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+          BRANCH: gh-pages
+          FOLDER: site
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -132,7 +132,6 @@ jobs:
             file: coverage-${{ matrix.python-version }}.xml
             fail_ci_if_error: true
 
-
   verify-wheel:
     runs-on: ubuntu-latest
     steps:
@@ -145,3 +144,20 @@ jobs:
         uses: ./.github/actions/verify-wheel
         with:
           package-import-name: "columbo"
+
+  build-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Build Docs
+        run: docker-compose run --rm mkdocs build --strict
+
+      - name: Upload coverage results artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: docs-site
+          path: site/
+        # Use always() to always run this step to publish test results when there are test failures
+        if: ${{ always() }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -154,21 +154,40 @@ jobs:
       - name: Build Docs
         run: docker-compose run --rm mkdocs build --strict
 
+#      # publish to a dev directory & don't clean anything
+#      - name: Publish (dev)
+#        uses: JamesIves/github-pages-deploy-action@releases/v3
+#        if: github.event_name == 'push' && github.ref != 'refs/heads/main'
+#        with:
+#          ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+#          BRANCH: gh-pages
+#          FOLDER: site
+#          TARGET_FOLDER: _dev/
+#
+#      # publish to the root and clean everything
+#      - name: Publish (prod)
+#        uses: JamesIves/github-pages-deploy-action@releases/v3
+#        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+#        with:
+#          ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+#          BRANCH: gh-pages
+#          FOLDER: site
+
+      # publish to the root and clean everything
+      - name: Publish (prod)
+        uses: JamesIves/github-pages-deploy-action@releases/v3
+        with:
+          ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+          BRANCH: gh-pages
+          FOLDER: site
+
       # publish to a dev directory & don't clean anything
       - name: Publish (dev)
         uses: JamesIves/github-pages-deploy-action@releases/v3
-        if: github.event_name == 'push' && github.ref != 'refs/heads/main'
         with:
           ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
           BRANCH: gh-pages
           FOLDER: site
           TARGET_FOLDER: _dev/
+          CLEAN: false
 
-      # publish to the root and clean everything
-      - name: Publish (prod)
-        uses: JamesIves/github-pages-deploy-action@releases/v3
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        with:
-          ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
-          BRANCH: gh-pages
-          FOLDER: site

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -154,6 +154,10 @@ jobs:
       - name: Build Docs
         run: docker-compose run --rm mkdocs build --strict
 
+      - name: Extract branch name
+        shell: bash
+        run: echo "BRANCH_NAME=${GITHUB_REF#refs/heads/} | sed 's/\//_/g')" >> $GITHUB_ENV
+
       # publish to a dev directory & don't clean anything
       - name: Publish (dev)
         uses: JamesIves/github-pages-deploy-action@releases/v3
@@ -162,7 +166,7 @@ jobs:
           ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
           BRANCH: gh-pages
           FOLDER: site
-          TARGET_FOLDER: _dev/${GITHUB_REF##*/}
+          TARGET_FOLDER: _dev/${{ env.BRANCH_NAME }}
           CLEAN: false
 
       # publish to the root and clean everything

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -154,10 +154,22 @@ jobs:
       - name: Build Docs
         run: docker-compose run --rm mkdocs build --strict
 
-      - name: Upload coverage results artifact
-        uses: actions/upload-artifact@v2
+      # publish to a dev directory & don't clean anything
+      - name: Publish (dev)
+        uses: JamesIves/github-pages-deploy-action@releases/v3
+        if: github.event_name == 'push' && github.ref != 'refs/heads/main'
         with:
-          name: docs-site
-          path: site/
-        # Use always() to always run this step to publish test results when there are test failures
-        if: ${{ always() }}
+          ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+          BRANCH: gh-pages
+          FOLDER: site
+          TARGET_FOLDER: _dev/${GITHUB_REF##*/}
+          CLEAN: false
+
+      # publish to the root and clean everything
+      - name: Publish (prod)
+        uses: JamesIves/github-pages-deploy-action@releases/v3
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        with:
+          ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+          BRANCH: gh-pages
+          FOLDER: site

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-[![example branch parameter](https://github.com/wayfair-incubator/columbo/workflows/CI/badge.svg?branch=main)][ci]
-[![codecov](https://codecov.io/gh/wayfair-incubator/columbo/branch/main/graph/badge.svg)](https://codecov.io/gh/wayfair-incubator/columbo)
+[![CI pipeline status](https://github.com/wayfair-incubator/columbo/workflows/CI/badge.svg?branch=main)][ci]
+[![codecov](https://codecov.io/gh/wayfair-incubator/columbo/branch/main/graph/badge.svg)][codecov]
 TODO: PyPi Release Badge
 [![Checked with mypy](https://img.shields.io/badge/mypy-checked-blue)][mypy-home]
 [![Code style: black](https://img.shields.io/badge/code%20style-black-black.svg)][black-home]
@@ -115,6 +115,7 @@ TODO: Use Github Pages to host documentation.
 Check out the [project documentation][columbo-docs]
 
 [ci]: https://github.com/wayfair-incubator/columbo/actions
+[codecov]: https://codecov.io/gh/wayfair-incubator/columbo
 [mypy-home]: http://mypy-lang.org/
 [black-home]: https://github.com/psf/black
 [install-docker]: https://docs.docker.com/install/

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,3 +15,12 @@ services:
   test:
     <<: *devbox
     command: docker/run_tests.sh --format-code
+
+  # generate and serve the project documentation locally
+  mkdocs:
+    image: "squidfunk/mkdocs-material:6.0.2"
+    volumes:
+      - ./:/docs
+    ports:
+      - "8000:8000"
+

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,1 @@
+../CHANGELOG.md

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,3 @@
+# Reference
+
+TODO

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,18 @@
+# Getting Started
+
+## Installation
+
+To install `columbo`, simply run this simple command in your terminal of choice:
+
+```shell script
+$ python -m pip install columbo
+```
+
+## Basic Usage Examples
+
+TODO
+
+Read the [Usage Guide][usage_guide] for a more detailed descriptions of the ways `columbo` can be used.
+
+
+[usage_guide]: usage-guide.md

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,12 +6,25 @@ TODO: PyPi Release Badge
 
 `columbo` provides a way to specify a dynamic set of questions to ask a user and get their answers.
 
+`columbo`'s feature set allows a program to:
+
+* Ask multiple types of questions:
+    * Yes or No
+    * Multiple choice
+    * Open-ended
+* Validate the response provided by the user.
+* Use answers from earlier questions:
+    * As part of the text of a question
+    * As part of the text of a default value
+    * To decide if a question should be skipped
+* Accept answers from the command line in addition to prompting the user.
+
 ## Example
 
 ### User Prompts
 
 The primary use of `columbo` is to define a sequence of interactions that are used to prompt a user to provide answers
-using a terminal. Below is a sample which shows how this can be used.
+using a terminal. Below is a sample which shows some ways this can be used.
 
 ```python
 import columbo

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,89 @@
+# Columbo
+
+[![CI pipeline status](https://github.com/wayfair-incubator/columbo/workflows/CI/badge.svg?branch=main)][ci]
+[![codecov](https://codecov.io/gh/wayfair-incubator/columbo/branch/main/graph/badge.svg)][codecov]
+TODO: PyPi Release Badge
+
+`columbo` provides a way to specify a dynamic set of questions to ask a user and get their answers.
+
+## Example
+
+### User Prompts
+
+The primary use of `columbo` is to define a sequence of interaction that are used to prompt a user to provide answers
+using a terminal. Below is a sample which shows how this can be used.
+
+```python
+import columbo
+
+interactions = [
+    columbo.Echo("Welcome to the Columbo example"),
+    columbo.Acknowledge(
+        "Press enter to start"
+    ),
+    columbo.BasicQuestion(
+        "user",
+        "What is your name?",
+        default="Patrick",
+    ),
+    columbo.BasicQuestion(
+        "user_email",
+        lambda answers: f"""What email address should be used to contact {answers["user"]}?""",
+        default="me@example.com"
+    ),
+    columbo.Choice(
+        "mood",
+        "How are you feeling today?",
+        options=["happy", "sad", "sleepy", "confused"],
+        default="happy",
+    ),
+    columbo.Confirm("likes_dogs", "Do you like dogs?", default=True),
+]
+
+columbo.get_answers(interactions)
+```
+
+Below shows the output when the user accepts the default values for most of the questions. The user provides a different
+value for the email and explicitly confirms that they like dogs.
+
+```text
+Welcome to the Columbo example
+Press enter to start
+ 
+What is your name? [Patrick]:
+
+What email address should be used to contact Patrick? [me@example.com]: patrick@example.com
+
+How are you feeling today?
+1 - happy
+2 - sad
+3 - sleepy
+4 - confused
+Enter the number of your choice [1]:
+
+Do you like dogs? (Y/n): y
+
+{'user': 'Patrick', 'user_email': 'me@example.com', 'mood': 'happy', 'likes_dogs': True}
+```
+
+### Command Line Answers
+
+TODO
+
+## Where to Start?
+
+To learn the basics of how to start using `columbo`, read the [Getting Started][getting_started] page.
+
+## Detailed Documentation
+
+To learn more about the various ways `columbo` can be used, read the [Usage Guide][usage_guide] page.
+
+## API Reference
+
+To find specific information about a specific function or class, read the [API Reference][api_reference].
+
+[ci]: https://github.com/wayfair-incubator/columbo/actions
+[codecov]: https://codecov.io/gh/wayfair-incubator/columbo
+[getting_started]: getting-started.md
+[usage_guide]: usage-guide.md
+[api_reference]: api.md

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ TODO: PyPi Release Badge
 
 ### User Prompts
 
-The primary use of `columbo` is to define a sequence of interaction that are used to prompt a user to provide answers
+The primary use of `columbo` is to define a sequence of interactions that are used to prompt a user to provide answers
 using a terminal. Below is a sample which shows how this can be used.
 
 ```python

--- a/docs/index.md
+++ b/docs/index.md
@@ -93,7 +93,7 @@ To learn more about the various ways `columbo` can be used, read the [Usage Guid
 
 ## API Reference
 
-To find specific information about a specific function or class, read the [API Reference][api_reference].
+To find detailed information about a specific function or class, read the [API Reference][api_reference].
 
 [ci]: https://github.com/wayfair-incubator/columbo/actions
 [codecov]: https://codecov.io/gh/wayfair-incubator/columbo

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -1,0 +1,3 @@
+# Usage Guide
+
+TODO

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,13 @@
+site_name: columbo Documentation
+repo_url: https://github.com/wayfair-incubator/columbo/
+repo_name: wayfair-incubator/columbo
+docs_dir: docs
+nav:
+  - Overview: index.md
+  - Getting Started: getting-started.md
+  - Usage Guide: usage-guide.md
+  - Reference: api.md
+  - Changelog: CHANGELOG.md
+theme: material
+markdown_extensions:
+  - codehilite


### PR DESCRIPTION
Includes a starting point for documentation of the project.

I played around with trying to achieve a `_dev/` sub directory to host the rendered docs for a PR, but the page does not load properly. Dynamically creating a `mkdocs.yml` file with the updated `site_url` might work, but it might be an issue with the theme.

For now, the docs are built and uploaded as an artifact.