### PR TITLE
Add API documentation

### DIFF
--- a/columbo/_exception.py
+++ b/columbo/_exception.py
@@ -11,6 +11,7 @@ class DuplicateQuestionNameException(ColumboException):
 
 class CliException(ColumboException):
     """An error occurred while processing command line arguments."""
+
     @classmethod
     def invalid_value(
         cls, value: str, argument_name: str, error_message: Optional[str] = None

--- a/columbo/_exception.py
+++ b/columbo/_exception.py
@@ -10,6 +10,7 @@ class DuplicateQuestionNameException(ColumboException):
 
 
 class CliException(ColumboException):
+    """An error occurred while processing command line arguments."""
     @classmethod
     def invalid_value(
         cls, value: str, argument_name: str, error_message: Optional[str] = None

--- a/columbo/_interaction.py
+++ b/columbo/_interaction.py
@@ -93,7 +93,7 @@ class Acknowledge:
 
 class Question(ABC):
     """
-    A prompt to the user that produces an answer.
+    Base class for a prompt to the user that produces an answer.
     """
 
     def __init__(
@@ -154,6 +154,10 @@ class Question(ABC):
 
 
 class Confirm(Question):
+    """
+    A question with a yes or no answer.
+    """
+
     def __init__(
         self,
         name: str,
@@ -228,6 +232,9 @@ class Confirm(Question):
 
 
 class Choice(Question):
+    """
+    A question with a set of possible answers.
+    """
     def __init__(
         self,
         name: str,
@@ -322,6 +329,9 @@ class Choice(Question):
 
 
 class BasicQuestion(Question):
+    """
+    A question with an arbitrary text answer.
+    """
     def __init__(
         self,
         name: str,

--- a/columbo/_interaction.py
+++ b/columbo/_interaction.py
@@ -235,6 +235,7 @@ class Choice(Question):
     """
     A question with a set of possible answers.
     """
+
     def __init__(
         self,
         name: str,
@@ -332,6 +333,7 @@ class BasicQuestion(Question):
     """
     A question with an arbitrary text answer.
     """
+
     def __init__(
         self,
         name: str,

--- a/docker/devbox.dockerfile
+++ b/docker/devbox.dockerfile
@@ -20,7 +20,8 @@ RUN mkdir /app && chown ${UID}:${GID} /app
 
 USER ${_USER}
 
-COPY ./requirements*.txt /app/
+COPY --chown=${UID}:${GID} ./requirements*.txt /app/
+COPY --chown=${UID}:${GID} ./util /app/util/
 WORKDIR /app
 
 RUN pip install -r requirements.txt -r requirements-test.txt

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,3 +1,55 @@
 # Reference
 
-TODO
+## Type Aliases
+
+`columbo` uses type aliases heavily to simplify the annotations for the functions provided by the
+library. The following table defines the aliases that are used.
+
+| Alias | Value |
+| ----- | ----- |
+| `Answer` | `Union[bool, str]` |
+| `Answers` | `Mapping[str, Answer]` |
+| `Interaction` | `Union[Echo, Acknowledge, Question]` |
+| `MutableAnswers` | `MutableMapping[str, Answer]` |
+| `OptionList` | `List[str]` |
+| `Possible`* | `Union[T, Literal[_Sentinel]]` |
+| `ShouldAsk` | `Callable[[Answers], bool]` |
+| `StaticOrDynamicValue` | `Union[V, Callable[[Answers], V]]` |
+| `Validator` | `Callable[[str, Answers], Optional[str]]` |
+
+
+!!! note
+    `Possible` is a special construct used in `copy()` methods to indicate that a value was not
+    provided. `Possible` & `_Sentinel` are not exposed by `columbo`, but are documented here for
+    completeness.
+
+
+## Interactions
+
+::: columbo.Acknowledge
+
+::: columbo.BasicQuestion
+
+::: columbo.Choice
+
+::: columbo.Confirm
+
+::: columbo.Echo
+
+::: columbo.Question
+
+## Functions
+
+::: columbo.format_cli_help
+
+::: columbo.get_answers
+
+::: columbo.parse_args
+
+## Exceptions
+
+::: columbo.CliException
+
+::: columbo.ColumboException
+
+::: columbo.DuplicateQuestionNameException

--- a/docs/css/mkdocstrings.css
+++ b/docs/css/mkdocstrings.css
@@ -1,0 +1,33 @@
+/* Indentation. */
+div.doc-contents:not(.first) {
+  padding-left: 25px;
+  border-left: 4px solid rgba(230, 230, 230);
+  margin-bottom: 80px;
+}
+
+/* Don't capitalize names. */
+h5.doc-heading {
+  text-transform: none !important;
+}
+
+/* Don't use vertical space on hidden ToC entries. */
+.hidden-toc::before {
+  margin-top: 0 !important;
+  padding-top: 0 !important;
+}
+
+/* Don't show permalink of hidden ToC entries. */
+.hidden-toc a.headerlink {
+  display: none;
+}
+
+/* Avoid breaking parameters name, etc. in table cells. */
+td code {
+  word-break: normal !important;
+}
+
+/* For pieces of Markdown rendered in table cells. */
+td p {
+  margin-top: 0 !important;
+  margin-bottom: 0 !important;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,6 +37,7 @@ plugins:
             show_root_heading: True
             show_source: False
             show_root_full_path: False
+  - mkdocstrings_patch_type_aliases
 
 extra_css:
   - css/version-select.css

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,7 +27,19 @@ plugins:
       redirect_maps:
         usage-guide.md: usage-guide/fundamentals.md
         CHANGELOG.md: changelog.md
+  - mkdocstrings:
+      handlers:
+        python:
+          selection:
+            docstring_style: "restructured-text"
+          rendering:
+            heading_level: 3
+            show_root_heading: True
+            show_source: False
+            show_root_full_path: False
+
 extra_css:
   - css/version-select.css
+  - css/mkdocstrings.css
 extra_javascript:
   - js/version-select.js

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -13,3 +13,4 @@ pytest==6.2.1
 pytest-cov==2.10.1
 pytest-mock==3.5.0
 pdbpp
+./util/mkdocstrings_patch_type_aliases

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -7,6 +7,7 @@ mike==0.5.5
 mkdocs-material==6.2.3
 mkdocs-minify-plugin==0.3.0
 mkdocs-redirects==1.0.1
+mkdocstrings==0.14.0
 mypy==0.790
 pytest==6.2.1
 pytest-cov==2.10.1

--- a/util/mkdocstrings_patch_type_aliases/mkdocstrings_patch_type_aliases/__init__.py
+++ b/util/mkdocstrings_patch_type_aliases/mkdocstrings_patch_type_aliases/__init__.py
@@ -1,0 +1,1 @@
+from mkdocstrings_patch_type_aliases._plugin import PatchTypeAliases

--- a/util/mkdocstrings_patch_type_aliases/mkdocstrings_patch_type_aliases/_plugin.py
+++ b/util/mkdocstrings_patch_type_aliases/mkdocstrings_patch_type_aliases/_plugin.py
@@ -1,0 +1,76 @@
+import re
+from re import Pattern
+from typing import Callable
+
+from mkdocs.plugins import BasePlugin
+from mkdocs.structure.nav import Page
+
+ReplaceFunc = Callable[[str], str]
+
+
+def simple_replace(look_for: str, replace_with: str) -> ReplaceFunc:
+    def _replace(text: str) -> str:
+        return text.replace(look_for, replace_with)
+
+    return _replace
+
+
+def regex_replace(look_for: Pattern, replace_with: str) -> ReplaceFunc:
+    def _replace(text: str) -> str:
+        # breakpoint()
+        return re.sub(look_for, replace_with, text)
+
+    return _replace
+
+
+# Order is significant
+REPLACE_FUNCS = [
+    # Possible: Python flattens nested unions, so need special handling for normal and nested.
+    regex_replace(
+        re.compile(r"Union\[([][\w, ]+, ([][\w, ]+)), columbo\._interaction\._Sentinel]"),
+        r"Possible[Union[\1]]"
+    ),
+    regex_replace(
+        re.compile(r"Union\[([][\w, ]+), columbo\._interaction\._Sentinel]"),
+        r"Possible[\1]"
+    ),
+    # StaticOrDynamicValue: Handling for simple and generic types
+    regex_replace(
+        re.compile(r"Union\[(\w+), Callable\[\[Mapping\[str, Union\[bool, str]]], \w+]]"),
+        r"StaticOrDynamicValue[\1]"
+    ),
+    regex_replace(
+        re.compile(r"Union\[([][\w]+), Callable\[\[Mapping\[str, Union\[bool, str]]], [][\w]+]]"),
+        r"StaticOrDynamicValue[\1]]"
+    ),
+    simple_replace("Callable[[Mapping[str, Union[bool, str]]], bool]", "ShouldAsk"),
+    simple_replace("Callable[[str, Mapping[str, Union[bool, str]]], Optional[str]]", "Validator"),
+    simple_replace("Union[Echo, Acknowledge, Question]", "Interaction"),
+    simple_replace("Mapping[str, Union[bool, str]]", "Answers"),
+    # Wrapped with square brackets to not replace value in type alias table
+    simple_replace("[List[str]]", "[OptionList]"),
+    # Any Optional values that were flattened as a nested union
+    regex_replace(re.compile(r"Union\[(\w+), NoneType]"), r"Optional[\1]"),
+    # Sentinel
+    simple_replace("&lt;_Sentinel.A: 0&gt;", "_Sentinel"),
+    simple_replace(
+        """&lt;</span><span class="n">_Sentinel</span><span class="o">.</span>"""
+        """<span class="n">A</span><span class="p">:</span> <span class="mi">0</span>"""
+        """<span class="o">&gt;""",
+        """<span class="n">_Sentinel</span>"""),
+]
+
+
+class PatchTypeAliases(BasePlugin):
+    """
+    Manually put columbo type aliases back into documentation.
+
+    mkdocstrings shows the actual type instead of the type alias.
+    https://github.com/pawamoy/pytkdocs/issues/80
+    """
+
+    def on_post_page(self, output: str, page: Page, config: dict) -> str:
+        if page.title == "Reference":
+            for replace in REPLACE_FUNCS:
+                output = replace(output)
+        return output

--- a/util/mkdocstrings_patch_type_aliases/setup.py
+++ b/util/mkdocstrings_patch_type_aliases/setup.py
@@ -1,0 +1,20 @@
+# type: ignore
+import setuptools
+
+
+setuptools.setup(
+    name="mkdocstrings_patch_type_aliases",
+    version="0.1.alpha1",
+    packages=setuptools.find_packages(
+        exclude=["*.tests", "*.tests.*", "tests.*", "tests"]
+    ),
+    python_requires=">=3.6",
+    install_requires=[
+        "mkdocs~=1.0",
+    ],
+    entry_points={
+        "mkdocs.plugins": [
+            "mkdocstrings_patch_type_aliases = mkdocstrings_patch_type_aliases:PatchTypeAliases",
+        ]
+    }
+)


### PR DESCRIPTION
Includes custom mkdocs plugin to display type aliases (See pawamoy/pytkdocs#80)

![columbo-api-docs](https://user-images.githubusercontent.com/18636401/104198328-18e94b00-53f4-11eb-973e-896847ded50c.png)
