### PR TITLE
CI action to publish docs to dev version

### DIFF
--- a/.github/actions/publish-docs-with-mike/action.sh
+++ b/.github/actions/publish-docs-with-mike/action.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+echo "::group::Configure Git User"
+"${GITHUB_ACTION_PATH}/configure_git_user.sh"
+echo "::endgroup::"
+
+echo "::group::Pull down latest docs commit"
+git fetch --no-tags --prune --progress --no-recurse-submodules --depth=1 origin gh-pages
+echo "::endgroup::"
+
+echo "::group::Publish documentation"
+if [[ "${NEW_VERSION}" == "false" ]]; then
+  if [[ "${VERSION_NAME}" == "" ]]; then
+    echo "::error::'version_name' must be specified when 'NEW_VERSION' is false."
+    exit 1
+  fi
+  echo "mike deploy \"${VERSION_NAME}\""
+  mike deploy "${VERSION_NAME}"
+elif [[ "${GITHUB_EVENT_NAME:-}" != "release" ]]; then
+  echo "::error::new_version can only be used for release events."
+  exit 1
+else
+  # drop leading "v" from tag name to have just the version number
+  "${GITHUB_ACTION_PATH}/update_docs_for_version.sh" "${RELEASE_TAG:1}"
+fi
+echo "git push origin gh-pages"
+git push origin gh-pages
+echo "::endgroup::"

--- a/.github/actions/publish-docs-with-mike/action.yml
+++ b/.github/actions/publish-docs-with-mike/action.yml
@@ -1,0 +1,37 @@
+name: "Publish Docs with Mike"
+description: |
+  Publish versioned documentation with Mike.
+  Requires a python environment to already be setup with mike and any other documentation dependencies installed.
+inputs:
+  version_name:
+    description: |
+      Name a version to publish.
+      Required when new_version is false.
+    required: false
+    default: ""
+  new_version:
+    description: |
+      If true, publish a new docs version. If an existing version uses the alias/tile "latest",
+      update the records so that the new version becomes the latest version.
+      If version_name is given, that value will be used. Otherwise the release tag will be used.
+    required: false
+    default: "false"
+  commit_user_name:
+    description: "User name to use for commits. When omitted, the event values will be inspected to derive the name."
+    default: ""
+    required: false
+  commit_user_email:
+    description: "User email to use for commits. When omitted, the event values will be inspected to derive the email."
+    default: ""
+    required: false
+runs:
+  using: "composite"
+  steps:
+    - run: "$GITHUB_ACTION_PATH/action.sh"
+      shell: "bash"
+      env:
+        USER_NAME: ${{ inputs.name }}
+        USER_EMAIL: ${{ inputs.email }}
+        VERSION_NAME: ${{ inputs.version_name }}
+        NEW_VERSION: ${{ inputs.new_version }}
+        RELEASE_TAG: ${{ github.event.release.tag_name }}

--- a/.github/actions/publish-docs-with-mike/configure_git_user.sh
+++ b/.github/actions/publish-docs-with-mike/configure_git_user.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+NO_REPLY_SUFFIX="@users.noreply.github.com"
+
+function set_and_exit() {
+  local name="${USER_NAME:-$1}"
+  local email="${USER_EMAIL:-$2}"
+  git config --local user.name "${name}"
+  git config --local user.email "${email}"
+  exit 0
+}
+
+function json_query() {
+  jq -e "${1}" "${GITHUB_EVENT_PATH}"
+}
+
+if [[ "${USER_NAME}" != "" && "${USER_EMAIL}" != "" ]]; then
+  set_and_exit
+fi
+
+echo "::debug::Attempting push event pusher"
+if json_query ".push.pusher" > /dev/null ; then
+  echo "::debug::Found push event pusher"
+  set_and_exit "$(json_query '.push.pusher.name')" "$(json_query '.push.pusher.email')"
+fi
+
+echo "::debug::Attempting merge merged by"
+if json_query ".pull_request.merged_by" > /dev/null ; then
+  echo "::debug::Found pull request event merged by"
+  LOGIN="$(json_query '.pull_request.merged_by.login')"
+  set_and_exit "${LOGIN}" "${LOGIN}${NO_REPLY_SUFFIX}"
+fi
+
+echo "::debug::Attempting event sender"
+if json_query ".sender" > /dev/null ; then
+  echo "::debug::Found pull event sender"
+  LOGIN="$(json_query '.sender.login')"
+  set_and_exit "${LOGIN}" "${LOGIN}${NO_REPLY_SUFFIX}"
+fi
+
+echo "::debug::Falling back to GITHUB_ACTOR"
+LOGIN="${GITHUB_ACTOR:-github_action}"
+set_and_exit "${LOGIN}" "${LOGIN}${NO_REPLY_SUFFIX}"

--- a/.github/actions/publish-docs-with-mike/update_docs_for_version.sh
+++ b/.github/actions/publish-docs-with-mike/update_docs_for_version.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+NEW_VERSION="${1}"
+PREV_LATEST="$(mike list --json | jq --raw-output '.[] | select(.aliases == ["latest"]) | .version')"
+
+if [[ "${PREV_LATEST}" == "" ]]; then
+  echo "No previous version found using the latest alias. Nothing to retitle."
+else
+  echo "mike retitle --message \"Remove latest from title of ${PREV_LATEST}\" \"${PREV_LATEST}\" \"${PREV_LATEST}\""
+  mike retitle --message "Remove latest from title of ${PREV_LATEST}" "${PREV_LATEST}" "${PREV_LATEST}"
+fi
+echo "mike deploy --update-aliases --title \"${NEW_VERSION} (latest)\" \"${NEW_VERSION}\" \"latest\""
+mike deploy --update-aliases --title "${NEW_VERSION} (latest)" "${NEW_VERSION}" "latest"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -161,6 +161,7 @@ jobs:
       - name: Install dependencies
         uses: ./.github/actions/install-dependencies
         with:
+          requirements: "true"
           test-requirements: "true"
 
       - name: Build Docs
@@ -186,6 +187,7 @@ jobs:
       - name: Install dependencies
         uses: ./.github/actions/install-dependencies
         with:
+          requirements: "true"
           test-requirements: "true"
 
       - name: Push documentaiton changes

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,9 +1,11 @@
 name: CI
 
-# Triggers the workflow on push or pull request
-# events but only for the main branch
-on: [push, pull_request]
-
+# Workflow does NOT trigger on a feature branch until a pull request is created.
+# Workflow will always run when a pull request is merged to the default branch.
+on:
+  pull_request: {}
+  push:
+      branches: ["main"]
 env:
   PYTHON_VERSION: "3.8.5"
 
@@ -147,28 +149,46 @@ jobs:
 
   build-docs:
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'
+    if: github.event_name == 'pull_request'
     steps:
       - name: Check out code
         uses: actions/checkout@v2
 
-      - name: Build Docs
-        run: docker-compose run --rm mkdocs build --strict
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
 
-      # upload artifact for dev build
+      - name: Install dependencies
+        uses: ./.github/actions/install-dependencies
+        with:
+          test-requirements: "true"
+
+      - name: Build Docs
+        run: mkdocs build --strict
+
       - name: Upload coverage results artifact
-        if: github.ref != 'refs/heads/main'
         uses: actions/upload-artifact@v2
         with:
           name: docs-site
           path: site/
 
-      # publish to the root and clean everything
-      - name: Publish (prod)
-        uses: JamesIves/github-pages-deploy-action@releases/v3
-        if: github.ref == 'refs/heads/main'
-        with:
-          ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
-          BRANCH: gh-pages
-          FOLDER: site
+  update-dev-docs:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
 
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install dependencies
+        uses: ./.github/actions/install-dependencies
+        with:
+          test-requirements: "true"
+
+      - name: Push documentaiton changes
+        uses: ./.github/actions/publish-docs-with-mike
+        with:
+          version_name: dev


### PR DESCRIPTION
Merges to the default branch publishes docs to "dev" version.

A follow up PR will use the functionality to create a new numbered version when the version number changes.

Part of #38