### PR TITLE
Updating validation signature

### DIFF
--- a/columbo/__init__.py
+++ b/columbo/__init__.py
@@ -22,6 +22,8 @@ from columbo._types import (  # noqa: F401
     OptionList,
     ShouldAsk,
     StaticOrDynamicValue,
+    ValidationFailure,
+    ValidationSuccess,
     Validator,
 )
 

--- a/columbo/__init__.py
+++ b/columbo/__init__.py
@@ -23,6 +23,7 @@ from columbo._types import (  # noqa: F401
     ShouldAsk,
     StaticOrDynamicValue,
     ValidationFailure,
+    ValidationResponse,
     ValidationSuccess,
     Validator,
 )

--- a/columbo/_cli.py
+++ b/columbo/_cli.py
@@ -178,7 +178,7 @@ def _update_answers_validate(
     value = cast(str, cli_values.get(question.name))
     if value is None:
         value = to_value(question.default, answers, str)
-    result = question.validate(value, answers)
+    result = question._validate_and_convert(value, answers)
     if not result.valid:
         raise CliException.invalid_value(
             value, canonical_arg_name(question.name), result.error

--- a/columbo/_cli.py
+++ b/columbo/_cli.py
@@ -178,7 +178,7 @@ def _update_answers_validate(
     value = cast(str, cli_values.get(question.name))
     if value is None:
         value = to_value(question.default, answers, str)
-    result = question._validate_and_convert(value, answers)
+    result = question.validate(value, answers)
     if not result.valid:
         raise CliException.invalid_value(
             value, canonical_arg_name(question.name), result.error

--- a/columbo/_cli.py
+++ b/columbo/_cli.py
@@ -178,10 +178,10 @@ def _update_answers_validate(
     value = cast(str, cli_values.get(question.name))
     if value is None:
         value = to_value(question.default, answers, str)
-    error = question.validate(value, answers)
-    if error:
+    result = question.validate(value, answers)
+    if not result.valid:
         raise CliException.invalid_value(
-            value, canonical_arg_name(question.name), error
+            value, canonical_arg_name(question.name), result.error
         )
     answers[question.name] = value
 

--- a/columbo/_interaction.py
+++ b/columbo/_interaction.py
@@ -284,8 +284,7 @@ class Choice(Question):
         """
         options = to_value(self._options, answers, list)
         if value not in options:
-            error_message = f"Chosen value: {value} not in options"
-            return ValidationFailure(error=error_message)
+            return ValidationFailure(error=f"Chosen value: {value} not in options")
         return ValidationSuccess()
 
     def ask(self, answers: Answers, no_user_input: bool = False) -> str:

--- a/columbo/_interaction.py
+++ b/columbo/_interaction.py
@@ -13,9 +13,10 @@ from columbo._types import (
     ShouldAsk,
     StaticOrDynamicValue,
     V,
-    Validator,
     ValidationFailure,
+    ValidationResponse,
     ValidationSuccess,
+    Validator,
 )
 
 Interaction = Union["Echo", "Acknowledge", "Question"]
@@ -274,7 +275,7 @@ class Choice(Question):
     def default(self) -> StaticOrDynamicValue[str]:
         return self._default
 
-    def validate(self, value: str, answers: Answers) -> Optional[str]:
+    def validate(self, value: str, answers: Answers) -> ValidationResponse:
         options = to_value(self._options, answers, list)
         if value not in options:
             error_message = f"Chosen value: {value} not in options"
@@ -369,7 +370,7 @@ class BasicQuestion(Question):
     def default(self) -> StaticOrDynamicValue[str]:
         return self._default
 
-    def validate(self, value: str, answers: Answers) -> Optional[str]:
+    def validate(self, value: str, answers: Answers) -> ValidationResponse:
         if self._validator is None:
             return ValidationSuccess()
         if callable(self._validator):

--- a/columbo/_interaction.py
+++ b/columbo/_interaction.py
@@ -276,6 +276,12 @@ class Choice(Question):
         return self._default
 
     def validate(self, value: str, answers: Answers) -> ValidationResponse:
+        """Validate the value (a new answer).
+
+        :param value: The identifier that will be used as the key to access the this question's answer.
+        :param answers: The answers that have been provided this far.
+        :return: A ValidationFailure or ValidationSuccess object.
+        """
         options = to_value(self._options, answers, list)
         if value not in options:
             error_message = f"Chosen value: {value} not in options"
@@ -370,6 +376,12 @@ class BasicQuestion(Question):
         return self._default
 
     def validate(self, value: str, answers: Answers) -> ValidationResponse:
+        """Validate the value (a new answer).
+
+        :param value: The identifier that will be used as the key to access the this question's answer.
+        :param answers: The answers that have been provided this far.
+        :return: A ValidationFailure or ValidationSuccess object.
+        """
         if self._validator is None:
             return ValidationSuccess()
         if callable(self._validator):

--- a/columbo/_interaction.py
+++ b/columbo/_interaction.py
@@ -279,19 +279,8 @@ class Choice(Question):
         options = to_value(self._options, answers, list)
         if value not in options:
             error_message = f"Chosen value: {value} not in options"
-            return error_message
-        return None
-
-    def _validate_and_convert(
-        self, value: str, answers: Answers
-    ) -> Union[ValidationSuccess, ValidationFailure]:
-        """Validate the new value and convert the result from a legacy validation result to a ValidationFailure or ValidationSuccess."""
-        result = self.validate(value, answers)
-        # handle deprecated, legacy validator responses
-        if isinstance(result, str) and result:
-            return ValidationFailure(error=result)
-        else:
-            return ValidationSuccess()
+            return ValidationFailure(error=error_message)
+        return ValidationSuccess()
 
     def ask(self, answers: Answers, no_user_input: bool = False) -> str:
         """
@@ -382,29 +371,16 @@ class BasicQuestion(Question):
 
     def validate(self, value: str, answers: Answers) -> ValidationResponse:
         if self._validator is None:
-            return None
+            return ValidationSuccess()
         if callable(self._validator):
             result = self._validator(value, answers)
-            if isinstance(result, (ValidationSuccess, ValidationFailure)):
+            if isinstance(result, (ValidationFailure, ValidationSuccess)):
                 return result
             else:  # handle deprecated, legacy validator responses
                 if result:
-                    return result
-                return None
+                    return ValidationFailure(error=result)
+                return ValidationSuccess()
         raise ValueError(f"Invalid value for validate: {self._validator}")
-
-    def _validate_and_convert(
-        self, value: str, answers: Answers
-    ) -> Union[ValidationSuccess, ValidationFailure]:
-        """Validate the new value and convert the result from a legacy validation result to a ValidationFailure or ValidationSuccess."""
-        result = self.validate(value, answers)
-        if isinstance(result, (ValidationSuccess, ValidationFailure)):
-            return result
-        # handle deprecated, legacy validator responses
-        elif isinstance(result, str) and result:
-            return ValidationFailure(error=result)
-        else:
-            return ValidationSuccess()
 
     def ask(self, answers: Answers, no_user_input: bool = False) -> str:
         """
@@ -424,7 +400,7 @@ class BasicQuestion(Question):
                 no_user_input=no_user_input,
             )
 
-            result = self._validate_and_convert(answer, answers)
+            result = self.validate(answer, answers)
             if result.valid:
                 break
 

--- a/columbo/_interaction.py
+++ b/columbo/_interaction.py
@@ -287,12 +287,10 @@ class Choice(Question):
     ) -> Union[ValidationSuccess, ValidationFailure]:
         """Validate the new value and convert the result from a legacy validation result to a ValidationFailure or ValidationSuccess."""
         result = self.validate(value, answers)
-        if isinstance(result, (ValidationSuccess, ValidationFailure)):
-            return result
         # handle deprecated, legacy validator responses
-        elif isinstance(result, str):
+        if isinstance(result, str) and result:
             return ValidationFailure(error=result)
-        elif result is None:
+        else:
             return ValidationSuccess()
 
     def ask(self, answers: Answers, no_user_input: bool = False) -> str:
@@ -403,9 +401,9 @@ class BasicQuestion(Question):
         if isinstance(result, (ValidationSuccess, ValidationFailure)):
             return result
         # handle deprecated, legacy validator responses
-        elif isinstance(result, str):
+        elif isinstance(result, str) and result:
             return ValidationFailure(error=result)
-        elif result is None:
+        else:
             return ValidationSuccess()
 
     def ask(self, answers: Answers, no_user_input: bool = False) -> str:

--- a/columbo/_types.py
+++ b/columbo/_types.py
@@ -31,5 +31,8 @@ OptionList = List[str]
 V = TypeVar("V")
 StaticOrDynamicValue = Union[V, Callable[[Answers], V]]
 ShouldAsk = Callable[[Answers], bool]
-ValidationResponse = Union[ValidationSuccess, ValidationFailure]
+LegacyValidationResponse = Optional[str]
+ValidationResponse = Union[
+    ValidationSuccess, ValidationFailure, LegacyValidationResponse
+]
 Validator = Callable[[str, Answers], ValidationResponse]

--- a/columbo/_types.py
+++ b/columbo/_types.py
@@ -1,16 +1,13 @@
 """Type aliases used by the public API"""
 
+import sys
 from dataclasses import dataclass
-from typing import (
-    Callable,
-    List,
-    Literal,
-    Mapping,
-    MutableMapping,
-    Optional,
-    TypeVar,
-    Union,
-)
+from typing import Callable, List, Mapping, MutableMapping, Optional, TypeVar, Union
+
+if sys.version_info < (3, 8):
+    from typing_extensions import Literal  # this supports python < 3.8
+else:
+    from typing import Literal  # this is available in python 3.8+
 
 
 @dataclass

--- a/columbo/_types.py
+++ b/columbo/_types.py
@@ -2,7 +2,7 @@
 
 import sys
 from dataclasses import dataclass
-from typing import Callable, List, Mapping, MutableMapping, Optional, TypeVar, Union
+from typing import Callable, List, Mapping, MutableMapping, TypeVar, Union
 
 if sys.version_info < (3, 8):
     from typing_extensions import Literal  # this supports python < 3.8

--- a/columbo/_types.py
+++ b/columbo/_types.py
@@ -1,6 +1,19 @@
 """Type aliases used by the public API"""
 
-from typing import Callable, List, Mapping, MutableMapping, Optional, TypeVar, Union
+from dataclasses import dataclass
+from typing import Callable, List, Mapping, MutableMapping, Optional, TypeVar, Union, Literal
+
+
+@dataclass
+class ValidationSuccess:
+   valid: Literal[True] = True
+
+
+@dataclass
+class ValidationFailure:
+   valid: Literal[False] = False
+   error: Optional[str] = None
+
 
 Answer = Union[bool, str]
 Answers = Mapping[str, Answer]
@@ -9,4 +22,5 @@ OptionList = List[str]
 V = TypeVar("V")
 StaticOrDynamicValue = Union[V, Callable[[Answers], V]]
 ShouldAsk = Callable[[Answers], bool]
-Validator = Callable[[str, Answers], Optional[str]]
+ValidationResponse = Union[ValidationSuccess, ValidationFailure]
+Validator = Callable[[str, Answers], ValidationResponse]

--- a/columbo/_types.py
+++ b/columbo/_types.py
@@ -29,4 +29,4 @@ V = TypeVar("V")
 StaticOrDynamicValue = Union[V, Callable[[Answers], V]]
 ShouldAsk = Callable[[Answers], bool]
 ValidationResponse = Union[ValidationSuccess, ValidationFailure]
-Validator = Callable[[str, Answers], ValidationResponse]
+Validator = Callable[[str, Answers], Union[ValidationResponse,  Optional[str]]

--- a/columbo/_types.py
+++ b/columbo/_types.py
@@ -1,18 +1,27 @@
 """Type aliases used by the public API"""
 
 from dataclasses import dataclass
-from typing import Callable, List, Mapping, MutableMapping, Optional, TypeVar, Union, Literal
+from typing import (
+    Callable,
+    List,
+    Literal,
+    Mapping,
+    MutableMapping,
+    Optional,
+    TypeVar,
+    Union,
+)
 
 
 @dataclass
 class ValidationSuccess:
-   valid: Literal[True] = True
+    valid: Literal[True] = True
 
 
 @dataclass
 class ValidationFailure:
-   valid: Literal[False] = False
-   error: Optional[str] = None
+    valid: Literal[False] = False
+    error: Optional[str] = None
 
 
 Answer = Union[bool, str]

--- a/columbo/_types.py
+++ b/columbo/_types.py
@@ -28,8 +28,5 @@ OptionList = List[str]
 V = TypeVar("V")
 StaticOrDynamicValue = Union[V, Callable[[Answers], V]]
 ShouldAsk = Callable[[Answers], bool]
-LegacyValidationResponse = Optional[str]
-ValidationResponse = Union[
-    ValidationSuccess, ValidationFailure, LegacyValidationResponse
-]
+ValidationResponse = Union[ValidationSuccess, ValidationFailure]
 Validator = Callable[[str, Answers], ValidationResponse]

--- a/columbo/_types.py
+++ b/columbo/_types.py
@@ -20,8 +20,8 @@ class ValidationSuccess:
 
 @dataclass
 class ValidationFailure:
+    error: str
     valid: Literal[False] = False
-    error: Optional[str] = None
 
 
 Answer = Union[bool, str]

--- a/columbo/_types.py
+++ b/columbo/_types.py
@@ -2,7 +2,7 @@
 
 import sys
 from dataclasses import dataclass
-from typing import Callable, List, Mapping, MutableMapping, TypeVar, Union
+from typing import Callable, List, Mapping, MutableMapping, Optional, TypeVar, Union
 
 if sys.version_info < (3, 8):
     from typing_extensions import Literal  # this supports python < 3.8
@@ -29,4 +29,4 @@ V = TypeVar("V")
 StaticOrDynamicValue = Union[V, Callable[[Answers], V]]
 ShouldAsk = Callable[[Answers], bool]
 ValidationResponse = Union[ValidationSuccess, ValidationFailure]
-Validator = Callable[[str, Answers], Union[ValidationResponse,  Optional[str]]
+Validator = Callable[[str, Answers], Union[ValidationResponse, Optional[str]]]

--- a/docs/api.md
+++ b/docs/api.md
@@ -9,14 +9,14 @@ library. The following table defines the aliases that are used.
 | ----- | ----- |
 | `Answer` | `Union[bool, str]` |
 | `Answers` | `Mapping[str, Answer]` |
-| `Interaction` | `Union["Echo", "Acknowledge", "Question"]` |
+| `Interaction` | `Union[Echo, Acknowledge, Question]` |
 | `MutableAnswers` | `MutableMapping[str, Answer]` |
 | `OptionList` | `List[str]` |
 | `Possible`* | `Union[T, Literal[_Sentinel]]` |
 | `ShouldAsk` | `Callable[[Answers], bool]` |
 | `StaticOrDynamicValue` | `Union[V, Callable[[Answers], V]]` |
-| `Validator` | `Callable[[str, Answers], Optional[str]]` |
-
+| `ValidationResponse` | `Union[ValidationSuccess, ValidationFailure]` |
+| `Validator` | `Callable[[str, Answers], ValidationResponse]` |
 
 !!! note
     `Possible` is a special construct used in `copy()` methods to indicate that a value was not

--- a/docs/api.md
+++ b/docs/api.md
@@ -16,7 +16,7 @@ library. The following table defines the aliases that are used.
 | `ShouldAsk` | `Callable[[Answers], bool]` |
 | `StaticOrDynamicValue` | `Union[V, Callable[[Answers], V]]` |
 | `ValidationResponse` | `Union[ValidationSuccess, ValidationFailure]` |
-| `Validator` | `Callable[[str, Answers], ValidationResponse]` |
+| `Validator` | `Callable[[str, Answers],  Union[ValidationResponse,  Optional[str]]]` |
 
 !!! note
     `Possible` is a special construct used in `copy()` methods to indicate that a value was not

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 prompt-toolkit==3.0.14
+typing_extensions; python_version < '3.8'

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ classifiers =
 python_requires = >=3.6
 install_requires =
     prompt-toolkit~=3.0
-    typing_extensions; python_version < '3.8'
+    typing_extensions~=3.7; python_version < '3.8'
 packages = find:
 
 [options.package_data]

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,9 @@ classifiers =
 [options]
 
 python_requires = >=3.6
-install_requires = prompt-toolkit~=3.0
+install_requires =
+    prompt-toolkit~=3.0
+    typing_extensions; python_version < '3.8'
 packages = find:
 
 [options.package_data]

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -8,6 +8,7 @@ from columbo import (
     CliException,
     Confirm,
     DuplicateQuestionNameException,
+    Echo,
     parse_args,
 )
 from columbo._cli import create_parser, format_cli_help, to_answers
@@ -309,6 +310,14 @@ def test_to_answer__confirm_value_set__set_value():
 
 def test_to_answer__confirm_dont_ask__value_not_stored():
     questions = [Confirm(SOME_NAME, SOME_STRING, should_ask=lambda _: False)]
+
+    result = to_answers(questions, Namespace(**{SOME_NAME: SOME_STRING}))
+
+    assert SOME_NAME not in result
+
+
+def test_to_answer__echo__value_not_stored():
+    questions = [Echo(SOME_STRING)]
 
     result = to_answers(questions, Namespace(**{SOME_NAME: SOME_STRING}))
 

--- a/tests/interaction_test.py
+++ b/tests/interaction_test.py
@@ -161,9 +161,9 @@ def test_choice__dynamic_message__multiple_choice_dynamic_message(mocker):
 def test_choice_is_valid__static_options__expected_result(value, is_valid):
     question = Choice(SOME_NAME, SOME_STRING, SOME_OPTIONS, SOME_DEFAULT)
 
-    error = question.validate(value, SOME_ANSWERS)
+    result = question.validate(value, SOME_ANSWERS)
 
-    assert (error is None) == is_valid
+    assert result.valid == is_valid
 
 
 @pytest.mark.parametrize(
@@ -172,9 +172,9 @@ def test_choice_is_valid__static_options__expected_result(value, is_valid):
 def test_choice_is_valid__dynamic_options__expected_result(value, is_valid):
     question = Choice(SOME_NAME, SOME_STRING, some_dynamic_options, SOME_DEFAULT)
 
-    error = question.validate(value, SOME_ANSWERS)
+    result = question.validate(value, SOME_ANSWERS)
 
-    assert (error is None) == is_valid
+    assert result.valid == is_valid
 
 
 @pytest.mark.parametrize(
@@ -183,7 +183,7 @@ def test_choice_is_valid__dynamic_options__expected_result(value, is_valid):
 def test_choice__validate__dynamic_options__expected_result(value, is_valid):
     question = Choice(SOME_NAME, SOME_STRING, some_dynamic_options, SOME_DEFAULT)
 
-    result = question._validate_and_convert(value, SOME_ANSWERS)
+    result = question.validate(value, SOME_ANSWERS)
 
     assert result.valid == is_valid
 
@@ -367,9 +367,9 @@ def test_basic_question_copy__diff_message__confirm_diff_message(mocker):
 def test_basic_question_is_valid__no_validator__always_valid(value):
     question = BasicQuestion(SOME_NAME, SOME_STRING, SOME_DEFAULT)
 
-    error = question.validate(value, SOME_ANSWERS)
+    result = question.validate(value, SOME_ANSWERS)
 
-    assert not error
+    assert result.valid
 
 
 @pytest.mark.parametrize(
@@ -383,9 +383,9 @@ def test_basic_question_is_valid__legacy_validator__result_of_validator(
         SOME_NAME, SOME_STRING, SOME_DEFAULT, validator=lambda v, a: validator_response
     )
 
-    error = question.validate(SOME_STRING, SOME_ANSWERS)
+    result = question.validate(SOME_STRING, SOME_ANSWERS)
 
-    assert (error is None) == is_valid
+    assert result.valid == is_valid
 
 
 @pytest.mark.parametrize(

--- a/tests/interaction_test.py
+++ b/tests/interaction_test.py
@@ -177,6 +177,17 @@ def test_choice_is_valid__dynamic_options__expected_result(value, is_valid):
     assert (error is None) == is_valid
 
 
+@pytest.mark.parametrize(
+    "value,is_valid", [(SOME_DYNAMIC_DEFAULT_RESULT, True), (SOME_STRING, False)]
+)
+def test_choice__validate__dynamic_options__expected_result(value, is_valid):
+    question = Choice(SOME_NAME, SOME_STRING, some_dynamic_options, SOME_DEFAULT)
+
+    result = question._validate_and_convert(value, SOME_ANSWERS)
+
+    assert result.valid == is_valid
+
+
 def test_choice_copy__new_instance():
     original = Choice(
         SOME_NAME, some_dynamic_string, some_dynamic_options, some_dynamic_default
@@ -281,6 +292,14 @@ def test_basic_question__no_input__default_value():
     result = BasicQuestion(SOME_NAME, SOME_STRING, SOME_DEFAULT).ask(
         SOME_ANSWERS, no_user_input=True
     )
+
+    assert result == SOME_DEFAULT
+
+
+def test_basic_question__ask__validator__default_value():
+    result = BasicQuestion(
+        SOME_NAME, SOME_STRING, SOME_DEFAULT, validator=lambda v, a: ValidationSuccess()
+    ).ask(SOME_ANSWERS, no_user_input=True)
 
     assert result == SOME_DEFAULT
 

--- a/tests/interaction_test.py
+++ b/tests/interaction_test.py
@@ -161,8 +161,9 @@ def test_choice__dynamic_message__multiple_choice_dynamic_message(mocker):
 def test_choice_is_valid__static_options__expected_result(value, is_valid):
     question = Choice(SOME_NAME, SOME_STRING, SOME_OPTIONS, SOME_DEFAULT)
 
-    result = question.validate(value, SOME_ANSWERS)
-    assert result.valid == is_valid
+    error = question.validate(value, SOME_ANSWERS)
+
+    assert (error is None) == is_valid
 
 
 @pytest.mark.parametrize(
@@ -171,8 +172,9 @@ def test_choice_is_valid__static_options__expected_result(value, is_valid):
 def test_choice_is_valid__dynamic_options__expected_result(value, is_valid):
     question = Choice(SOME_NAME, SOME_STRING, some_dynamic_options, SOME_DEFAULT)
 
-    result = question.validate(value, SOME_ANSWERS)
-    assert result.valid == is_valid
+    error = question.validate(value, SOME_ANSWERS)
+
+    assert (error is None) == is_valid
 
 
 def test_choice_copy__new_instance():
@@ -346,9 +348,25 @@ def test_basic_question_copy__diff_message__confirm_diff_message(mocker):
 def test_basic_question_is_valid__no_validator__always_valid(value):
     question = BasicQuestion(SOME_NAME, SOME_STRING, SOME_DEFAULT)
 
-    result = question.validate(value, SOME_ANSWERS)
+    error = question.validate(value, SOME_ANSWERS)
 
-    assert result.valid
+    assert not error
+
+
+@pytest.mark.parametrize(
+    ["is_valid", "validator_response"],
+    [(True, None), (False, "some-error")],
+)
+def test_basic_question_is_valid__legacy_validator__result_of_validator(
+    is_valid, validator_response
+):
+    question = BasicQuestion(
+        SOME_NAME, SOME_STRING, SOME_DEFAULT, validator=lambda v, a: validator_response
+    )
+
+    error = question.validate(SOME_STRING, SOME_ANSWERS)
+
+    assert (error is None) == is_valid
 
 
 @pytest.mark.parametrize(

--- a/tests/interaction_test.py
+++ b/tests/interaction_test.py
@@ -7,8 +7,8 @@ from columbo import (
     Confirm,
     DuplicateQuestionNameException,
     Echo,
-    ValidationSuccess,
     ValidationFailure,
+    ValidationSuccess,
 )
 from columbo._interaction import canonical_arg_name, get_answers, to_value
 from tests.sample_data import (
@@ -352,7 +352,8 @@ def test_basic_question_is_valid__no_validator__always_valid(value):
 
 
 @pytest.mark.parametrize(
-    ["is_valid", "validator_response"], [(True, ValidationSuccess()), (False, ValidationFailure(error="some-error"))]
+    ["is_valid", "validator_response"],
+    [(True, ValidationSuccess()), (False, ValidationFailure(error="some-error"))],
 )
 def test_basic_question_is_valid__validator__result_of_validator(
     is_valid, validator_response

--- a/tests/interaction_test.py
+++ b/tests/interaction_test.py
@@ -7,6 +7,8 @@ from columbo import (
     Confirm,
     DuplicateQuestionNameException,
     Echo,
+    ValidationSuccess,
+    ValidationFailure,
 )
 from columbo._interaction import canonical_arg_name, get_answers, to_value
 from tests.sample_data import (
@@ -159,9 +161,8 @@ def test_choice__dynamic_message__multiple_choice_dynamic_message(mocker):
 def test_choice_is_valid__static_options__expected_result(value, is_valid):
     question = Choice(SOME_NAME, SOME_STRING, SOME_OPTIONS, SOME_DEFAULT)
 
-    error = question.validate(value, SOME_ANSWERS)
-
-    assert (error is None) == is_valid
+    result = question.validate(value, SOME_ANSWERS)
+    assert result.valid == is_valid
 
 
 @pytest.mark.parametrize(
@@ -170,8 +171,8 @@ def test_choice_is_valid__static_options__expected_result(value, is_valid):
 def test_choice_is_valid__dynamic_options__expected_result(value, is_valid):
     question = Choice(SOME_NAME, SOME_STRING, some_dynamic_options, SOME_DEFAULT)
 
-    error = question.validate(value, SOME_ANSWERS)
-    assert (error is None) == is_valid
+    result = question.validate(value, SOME_ANSWERS)
+    assert result.valid == is_valid
 
 
 def test_choice_copy__new_instance():
@@ -345,13 +346,13 @@ def test_basic_question_copy__diff_message__confirm_diff_message(mocker):
 def test_basic_question_is_valid__no_validator__always_valid(value):
     question = BasicQuestion(SOME_NAME, SOME_STRING, SOME_DEFAULT)
 
-    error = question.validate(value, SOME_ANSWERS)
+    result = question.validate(value, SOME_ANSWERS)
 
-    assert not error
+    assert result.valid
 
 
 @pytest.mark.parametrize(
-    ["is_valid", "validator_response"], [(True, None), (False, "some-error")]
+    ["is_valid", "validator_response"], [(True, ValidationSuccess()), (False, ValidationFailure(error="some-error"))]
 )
 def test_basic_question_is_valid__validator__result_of_validator(
     is_valid, validator_response
@@ -360,9 +361,9 @@ def test_basic_question_is_valid__validator__result_of_validator(
         SOME_NAME, SOME_STRING, SOME_DEFAULT, validator=lambda v, a: validator_response
     )
 
-    error = question.validate(SOME_STRING, SOME_ANSWERS)
+    result = question.validate(SOME_STRING, SOME_ANSWERS)
 
-    assert (error is None) == is_valid
+    assert result.valid == is_valid
 
 
 def test_basic_question_is_valid__invalid_validator__exception():


### PR DESCRIPTION
Fixes #37 .

Todo:

- [x] update documentation
- [x] update `Literal` import for python versions < 3.8 (see https://github.com/wayfair-incubator/columbo/pull/88/checks?check_run_id=1858256105)
- [x] retain support for legacy validator
- [x] update new ValidationFailure to require an error string