### PR TITLE
Adding deprecation warning when old validator signature is used

### DIFF
--- a/columbo/_interaction.py
+++ b/columbo/_interaction.py
@@ -1,4 +1,5 @@
 import re
+import warnings
 from abc import ABC, abstractmethod
 from enum import Enum
 from typing import Collection, Optional, Type, TypeVar, Union
@@ -31,6 +32,8 @@ class _Sentinel(Enum):
 T = TypeVar("T")
 _NOT_GIVEN = _Sentinel.A
 Possible = Union[T, _Sentinel]
+
+VALIDATOR_UPGRADE_DOCS_LINK = "https://wayfair-incubator.github.io/columbo/latest/usage-guide/validators/#upgrading-validator-structure"
 
 
 # value is Possible[T]. The type is explicitly not annotated because of a conflict when T is a union. The type system
@@ -388,6 +391,11 @@ class BasicQuestion(Question):
             if isinstance(result, (ValidationFailure, ValidationSuccess)):
                 return result
             else:  # handle deprecated, legacy validator responses
+                warnings.warn(
+                    f"You are using a validator {self._validator} that returns content in a way will be deprecated at the 1.0.0 release."
+                    + f"For information on how to upgrade, please refer to the documentation here: {VALIDATOR_UPGRADE_DOCS_LINK}",
+                    DeprecationWarning,
+                )
                 if result:
                     return ValidationFailure(error=result)
                 return ValidationSuccess()

--- a/columbo/_interaction.py
+++ b/columbo/_interaction.py
@@ -33,7 +33,7 @@ T = TypeVar("T")
 _NOT_GIVEN = _Sentinel.A
 Possible = Union[T, _Sentinel]
 
-VALIDATOR_UPGRADE_DOCS_LINK = "https://wayfair-incubator.github.io/columbo/latest/usage-guide/validators/#upgrading-validator-structure"
+VALIDATOR_UPGRADE_DOCS_LINK = "https://wayfair-incubator.github.io/columbo/0.10.0/usage-guide/validators/#upgrading-validator-structure"
 
 
 # value is Possible[T]. The type is explicitly not annotated because of a conflict when T is a union. The type system

--- a/columbo/_interaction.py
+++ b/columbo/_interaction.py
@@ -392,7 +392,7 @@ class BasicQuestion(Question):
                 return result
             else:  # handle deprecated, legacy validator responses
                 warnings.warn(
-                    f"You are using a validator {self._validator} that returns content in a way will be deprecated at the 1.0.0 release."
+                    f"You are using a validator {self._validator} that returns content in a way is deprecated and will be removed after the 1.0.0 release."
                     + f"For information on how to upgrade, please refer to the documentation here: {VALIDATOR_UPGRADE_DOCS_LINK}",
                     DeprecationWarning,
                 )

--- a/docs/usage-guide/validators.md
+++ b/docs/usage-guide/validators.md
@@ -15,17 +15,28 @@ the answer is not valid and ask them to try again.
 
 ## Validator Structure
 
-A `Validator` must be a function which has the following type signature: `Callable[[str, Answers], ValidationResponse]`. We'll walk through this signature explaining each part.
+A `Validator` must be a function which has the following type signature: `Callable[[str, Answers], ValidationResponse]`[^1]. We'll walk through this signature explaining each part.
 
 A `Validator` takes two arguments: a string (which is the response provided by the user to a question) and an `Answers` dictionary containing the answer for each previous question.
 
-The `Validator` must return either a `ValidationRespones` which is a type alias for: `Union[ValidationFailure, ValidationSuccess]`. Thus, a `Validator` must return either a `ValidationFailure` or a `ValidationSuccess` object. You should use a `ValidationSuccess` when the user's response is valid and `ValidationFailure` when the user's response is invalid. Both `ValidationFailure` and `ValidationSuccess` have a `valid` attribute that is `False` and `True`, respectively. A `ValidationFailure` requires that you provide an `error` which describes why the given value was invalid (`columbo` will display this message before asking users to answer the question again so users get some feedback about what they are doing wrong).
+The `Validator` must return a `ValidationResponse` which is a type alias for: `Union[ValidationFailure, ValidationSuccess]`[^1]. Thus, a `Validator` must return either a `ValidationFailure` or a `ValidationSuccess` object. You should use a `ValidationSuccess` when the user's response is valid and `ValidationFailure` when the user's response is invalid. Both `ValidationFailure` and `ValidationSuccess` have a `valid` attribute that is `False` and `True`, respectively. A `ValidationFailure` requires that you provide an `error` which describes why the given value was invalid (`columbo` will display this message before asking users to answer the question again so users get some feedback about what they are doing wrong).
+
+### Upgrading Validator Structure
+
+The docs in this section detail how to upgrade a `Validator` from a columbo version < `0.10.0` to the newer `Validator` structure. Feel free to skip this section if it's not pertinent to you.
+
+As described in footnote 1[^1], the desired response from a `Validator` has changed in version `0.10.0`. Previously, a `Validator` would return either an error message (as a string) if validation failed or `None` if the validation succeeded. To update a `Validator`, you should update the validator function to return `ValidationFailure` if validation fails and `ValidationSuccess` if the validation succeeds. The table below describes the old and new return values for different validation statuses. If you have questions or would like some clarification, please [raise an issue](https://github.com/wayfair-incubator/columbo/issues) and we'd be happy to help.
+
+| Validation Status | Old Return Value (before `0.10.0`) | New Return Value (since `0.10.0`) |
+| ----- | ----- | ----- |
+| Failed | "Some error message" | ValidationFailure(error="Some error message") |
+| Succeeded | None | ValidationSuccess() |
 
 ## Example Validator
 
 Let's say we were asking for a user's email address.
 The `Validator` below provides a simple check to see if
-the email address seems valid<sup>1</sup>. If the user's response doesn't contain an `@` character with at least one
+the email address seems valid[^2]. If the user's response doesn't contain an `@` character with at least one
 word character on each side then the response is invalid and the user will have to
 enter an email address again (hopefully a valid one this time).
 
@@ -55,7 +66,13 @@ user_answers = columbo.get_answers(interactions)
 print(user_answers)
 ```
 
-<sup>1</sup>: The regular expression for checking for an RFC 822 compliant email address is
-[overly complicated](http://www.ex-parrot.com/~pdw/Mail-RFC822-Address.html). Additionally, that only ensures that the
-text is valid. It does not confirm if the host will accept emails sent to that address or if the user is the owner of
-the email address.
+[^1]:
+    Technically, the type alias for a `Validator` is `Callable[[str, Answers], Union[ValidationResponse, Optional[str]]]` - the difference
+    from the documentation above is that a `Validator` can return either a `ValidationResponse` *or* `Optional[str]`. Returning `Optional[str]`
+    is NOT recommended as we have deprecated `Optional[str]` as a valid return type in version `0.10.0` and will be removing this capability in version `1.0.0`.
+    
+[^2]:
+    The regular expression for checking for an RFC 822 compliant email address is
+    [overly complicated](http://www.ex-parrot.com/~pdw/Mail-RFC822-Address.html). Additionally, that only ensures that the
+    text is valid. It does not confirm if the host will accept emails sent to that address or if the user is the owner of
+    the email address.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -19,6 +19,7 @@ theme: material
 markdown_extensions:
   - admonition
   - codehilite
+  - footnotes
   - pymdownx.highlight
   - pymdownx.keys
   - pymdownx.superfences

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -236,7 +236,8 @@ def test_to_answer__basic_question_value_not_valid__exception():
     ]
 
     with pytest.raises(CliException):
-        to_answers(questions, Namespace(**{SOME_NAME: SOME_STRING}))
+        with pytest.deprecated_call():
+            to_answers(questions, Namespace(**{SOME_NAME: SOME_STRING}))
 
 
 def test_to_answer__basic_question_dont_ask__value_not_stored():

--- a/tests/interaction_test.py
+++ b/tests/interaction_test.py
@@ -383,9 +383,9 @@ def test_basic_question_is_valid__legacy_validator__result_of_validator(
         SOME_NAME, SOME_STRING, SOME_DEFAULT, validator=lambda v, a: validator_response
     )
 
-    result = question.validate(SOME_STRING, SOME_ANSWERS)
-
-    assert result.valid == is_valid
+    with pytest.deprecated_call():
+        result = question.validate(SOME_STRING, SOME_ANSWERS)
+        assert result.valid == is_valid
 
 
 @pytest.mark.parametrize(
@@ -424,13 +424,14 @@ def test_basic_question__invalid_asked_multiple_times(mocker, validity_responses
 
     user_io_ask_mock = mocker.patch("columbo._interaction.user_io.ask")
 
-    # validator callable will return False and then True when invoked
-    BasicQuestion(
-        SOME_NAME,
-        SOME_STRING,
-        SOME_DEFAULT,
-        validator=mocker.Mock(side_effect=validity_responses),
-    ).ask(SOME_ANSWERS)
+    with pytest.deprecated_call():
+        # validator callable will return False and then True when invoked
+        BasicQuestion(
+            SOME_NAME,
+            SOME_STRING,
+            SOME_DEFAULT,
+            validator=mocker.Mock(side_effect=validity_responses),
+        ).ask(SOME_ANSWERS)
 
     assert user_io_ask_mock.call_count == len(validity_responses)
 


### PR DESCRIPTION
In this PR, I have:

- Updated _interaction.py to provide a `DeprecationWarning` when a validator using the old paradigm is used
  - I chose a `DeprecationWarning` because `DeprecationWarning`s are for "warnings about deprecated features when those warnings are intended for other Python developers" (see https://docs.python.org/3/library/warnings.html#warning-categories) which is the use-case we are going for (from my understanding - but feel free to correct me if I'm wrong on this)
- Updated validator documentation to note:
  - That validators using the old paradigm are still supported (although deprecated)
  - How to upgrade validator from old paradigm to the new one
- Updated tests to make sure DeprecationWarning is shown