### PR TITLE
Remove quotes from package classifiers

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,14 +8,14 @@ description = Specify a dynamic set of questions to ask a user and get their ans
 long_description = file: README.md
 long_description_content_type = text/markdown
 classifiers =
-    "Development Status :: 4 - Beta"
-    "Programming Language :: Python"
-    "Programming Language :: Python :: 3"
-    "Programming Language :: Python :: 3.6"
-    "Programming Language :: Python :: 3.7"
-    "Programming Language :: Python :: 3.8"
-    "Programming Language :: Python :: 3.9"
-    "License :: OSI Approved :: MIT License"
+    Development Status :: 4 - Beta
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    License :: OSI Approved :: MIT License
 
 [options]
 


### PR DESCRIPTION
The quotes were being retained in the wheel metadata and resulted in invalid classifiers.