### PR TITLE
Update command to fetch current branch

### DIFF
--- a/docker/bump_version.sh
+++ b/docker/bump_version.sh
@@ -56,7 +56,7 @@ elif [[ "${PART}" == "${PRE_RELEASE_ARG}" && "${DEV_RELEASE}" == "true" ]]; then
   usage
 fi
 
-CURRENT_BRANCH=$(git branch --show-current)
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 CURRENT_STATUS=$(git status --short --untracked-files=no)
 
 if [[ "${CURRENT_BRANCH}" != "${DEFAULT_BRANCH}" ]]; then


### PR DESCRIPTION
The `bump_version.sh` script was previously using `--show-current`, which is not supported in the version of git available on the devbox image (added in git `2.22`, but the debian image is still using `2.20.1`)