### PR TITLE
Removing deprecated validator signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Removed legacy validator signature and logic
+
 ## [0.10.1] - 2021-02-26
 
 ### Fixed

--- a/columbo/_interaction.py
+++ b/columbo/_interaction.py
@@ -1,5 +1,4 @@
 import re
-import warnings
 from abc import ABC, abstractmethod
 from enum import Enum
 from typing import Collection, Optional, Type, TypeVar, Union
@@ -32,8 +31,6 @@ class _Sentinel(Enum):
 T = TypeVar("T")
 _NOT_GIVEN = _Sentinel.A
 Possible = Union[T, _Sentinel]
-
-VALIDATOR_UPGRADE_DOCS_LINK = "https://wayfair-incubator.github.io/columbo/0.10.0/usage-guide/validators/#upgrading-validator-structure"
 
 
 # value is Possible[T]. The type is explicitly not annotated because of a conflict when T is a union. The type system
@@ -384,21 +381,13 @@ class BasicQuestion(Question):
         :param answers: The answers that have been provided this far.
         :return: A ValidationFailure or ValidationSuccess object.
         """
+
         if self._validator is None:
             return ValidationSuccess()
+
         if callable(self._validator):
-            result = self._validator(value, answers)
-            if isinstance(result, (ValidationFailure, ValidationSuccess)):
-                return result
-            else:  # handle deprecated, legacy validator responses
-                warnings.warn(
-                    f"You are using a validator {self._validator} that returns content in a way is deprecated and will be removed after the 1.0.0 release."
-                    + f"For information on how to upgrade, please refer to the documentation here: {VALIDATOR_UPGRADE_DOCS_LINK}",
-                    DeprecationWarning,
-                )
-                if result:
-                    return ValidationFailure(error=result)
-                return ValidationSuccess()
+            return self._validator(value, answers)
+
         raise ValueError(f"Invalid value for validate: {self._validator}")
 
     def ask(self, answers: Answers, no_user_input: bool = False) -> str:

--- a/columbo/_types.py
+++ b/columbo/_types.py
@@ -2,7 +2,7 @@
 
 import sys
 from dataclasses import dataclass
-from typing import Callable, List, Mapping, MutableMapping, Optional, TypeVar, Union
+from typing import Callable, List, Mapping, MutableMapping, TypeVar, Union
 
 if sys.version_info < (3, 8):
     from typing_extensions import Literal  # this supports python < 3.8
@@ -29,4 +29,4 @@ V = TypeVar("V")
 StaticOrDynamicValue = Union[V, Callable[[Answers], V]]
 ShouldAsk = Callable[[Answers], bool]
 ValidationResponse = Union[ValidationSuccess, ValidationFailure]
-Validator = Callable[[str, Answers], Union[ValidationResponse, Optional[str]]]
+Validator = Callable[[str, Answers], ValidationResponse]

--- a/docs/usage-guide/validators.md
+++ b/docs/usage-guide/validators.md
@@ -45,9 +45,9 @@ enter an email address again (hopefully a valid one this time).
 ```
 
 [^1]:
-    Technically, the type alias for a `Validator` is `Callable[[str, Answers], Union[ValidationResponse, Optional[str]]]` - the difference
+    Formerly, the type alias for a `Validator` was `Callable[[str, Answers], Union[ValidationResponse, Optional[str]]]` - the difference
     from the documentation above is that a `Validator` can return either a `ValidationResponse` *or* `Optional[str]`. Returning `Optional[str]`
-    is NOT recommended as we have deprecated `Optional[str]` as a valid return type in version `0.10.0` and will be removing this capability in version `1.0.0`.
+    is NOT recommended as we have deprecated `Optional[str]` as a valid return type in version `0.10.0` and have removed this capability in version `1.0.0`.
     
 [^2]:
     The regular expression for checking for an RFC 822 compliant email address is

--- a/docs/usage-guide/validators.md
+++ b/docs/usage-guide/validators.md
@@ -23,9 +23,11 @@ The `Validator` must return a `ValidationResponse` which is a type alias for: `U
 
 ### Upgrading Validator Structure
 
+Validators could return `Optional[str]` before <`0.10.0`, this was removed in `1.0.0`.
+
 The docs in this section detail how to upgrade a `Validator` from a columbo version < `0.10.0` to the newer `Validator` structure. Feel free to skip this section if it's not pertinent to you.
 
-As described in footnote 1[^1], the desired response from a `Validator` has changed in version `0.10.0`. Previously, a `Validator` would return either an error message (as a string) if validation failed or `None` if the validation succeeded. To update a `Validator`, you should update the validator function to return `ValidationFailure` if validation fails and `ValidationSuccess` if the validation succeeds. The table below describes the old and new return values for different validation statuses. If you have questions or would like some clarification, please [raise an issue](https://github.com/wayfair-incubator/columbo/issues) and we'd be happy to help.
+Previously, a `Validator` would return either an error message (as a string) if validation failed or `None` if the validation succeeded. To update a `Validator`, you should update the validator function to return `ValidationFailure` if validation fails and `ValidationSuccess` if the validation succeeds. The table below describes the old and new return values for different validation statuses. 
 
 | Validation Status | Old Return Value (before `0.10.0`) | New Return Value (since `0.10.0`) |
 | ----- | ----- | ----- |
@@ -36,7 +38,7 @@ As described in footnote 1[^1], the desired response from a `Validator` has chan
 
 Let's say we were asking for a user's email address.
 The `Validator` below provides a simple check to see if
-the email address seems valid[^2]. If the user's response doesn't contain an `@` character with at least one
+the email address seems valid[^1]. If the user's response doesn't contain an `@` character with at least one
 word character on each side then the response is invalid and the user will have to
 enter an email address again (hopefully a valid one this time).
 
@@ -45,11 +47,6 @@ enter an email address again (hopefully a valid one this time).
 ```
 
 [^1]:
-    Formerly, the type alias for a `Validator` was `Callable[[str, Answers], Union[ValidationResponse, Optional[str]]]` - the difference
-    from the documentation above is that a `Validator` can return either a `ValidationResponse` *or* `Optional[str]`. Returning `Optional[str]`
-    is NOT recommended as we have deprecated `Optional[str]` as a valid return type in version `0.10.0` and have removed this capability in version `1.0.0`.
-    
-[^2]:
     The regular expression for checking for an RFC 822 compliant email address is
     [overly complicated](http://www.ex-parrot.com/~pdw/Mail-RFC822-Address.html). Additionally, that only ensures that the
     text is valid. It does not confirm if the host will accept emails sent to that address or if the user is the owner of

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -9,6 +9,7 @@ from columbo import (
     Confirm,
     DuplicateQuestionNameException,
     Echo,
+    ValidationFailure,
     parse_args,
 )
 from columbo._cli import create_parser, format_cli_help, to_answers
@@ -231,7 +232,10 @@ def test_to_answer__basic_question_value_set__set_value():
 def test_to_answer__basic_question_value_not_valid__exception():
     questions = [
         BasicQuestion(
-            SOME_NAME, SOME_STRING, SOME_DEFAULT, validator=lambda v, a: "some-error"
+            SOME_NAME,
+            SOME_STRING,
+            SOME_DEFAULT,
+            validator=lambda v, a: ValidationFailure("some-error"),
         )
     ]
 


### PR DESCRIPTION
- Removed the legacy validator signature
- Updated the tests to account for this
- Updated the docs
- Update the change log

closes #40 