### PR TITLE
Add search plugin to docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,6 +27,7 @@ markdown_extensions:
   - pymdownx.keys
   - pymdownx.superfences
 plugins:
+  - search
   - redirects:
       redirect_maps:
         usage-guide.md: usage-guide/fundamentals.md


### PR DESCRIPTION
The plugin is enabled by default. However, if you add a different plugin, the search plugin needs to be explicitly listed.

Fixes #134 