### PR TITLE
Making note of default for Confirm interactions

### DIFF
--- a/docs/usage-guide/interactions.md
+++ b/docs/usage-guide/interactions.md
@@ -48,7 +48,7 @@ In addition to the arguments [mentioned above](#all-questions), `Choice` also ac
 ### Confirm
 
 `Confirm` doesn't take any additional arguments that weren't [mentioned above](#all-questions). However, the `default`
-argument takes a `bool` instead of `str`.
+argument takes a `bool` instead of `str` and defaults to `False`.
 
 [optional-questions]: optional-questions-and-branching.md
 [command-line]: command-line.md


### PR DESCRIPTION
I updated the docs for the [Confirm](https://wayfair-incubator.github.io/columbo/latest/usage-guide/interactions/#confirm) interaction to note that the default value is `False` (which is, I think, helpful to know).