### PR TITLE
Publish docs base on pre-release status

### DIFF
--- a/.github/actions/publish-docs-with-mike/action.yml
+++ b/.github/actions/publish-docs-with-mike/action.yml
@@ -11,8 +11,8 @@ inputs:
     default: ""
   new_version:
     description: |
-      If true, publish a new docs version. If an existing version uses the alias/tile "latest",
-      update the records so that the new version becomes the latest version.
+      If true, publish a new docs version. When this release is NOT a prerelease, give this newly published version the
+      alias "latest". Any existing version that currently uses the "latest" alias will have that alias removed.
       If version_name is given, that value will be used. Otherwise the release tag will be used.
     required: false
     default: "false"
@@ -34,4 +34,5 @@ runs:
         USER_EMAIL: ${{ inputs.email }}
         VERSION_NAME: ${{ inputs.version_name }}
         NEW_VERSION: ${{ inputs.new_version }}
+        IS_PRERELEASE: ${{ github.event.release.prerelease }}
         RELEASE_TAG: ${{ github.event.release.tag_name }}

--- a/.github/actions/publish-docs-with-mike/update_docs_for_version.sh
+++ b/.github/actions/publish-docs-with-mike/update_docs_for_version.sh
@@ -6,10 +6,17 @@ NEW_VERSION="${1}"
 PREV_LATEST="$(mike list --json | jq --raw-output '.[] | select(.aliases == ["latest"]) | .version')"
 
 if [[ "${PREV_LATEST}" == "" ]]; then
-  echo "No previous version found using the latest alias. Nothing to retitle."
-else
+  echo "No previous version found using the latest alias. Nothing to re-title."
+elif [[ "${IS_PRERELEASE}" != "true" ]]; then
   echo "mike retitle --message \"Remove latest from title of ${PREV_LATEST}\" \"${PREV_LATEST}\" \"${PREV_LATEST}\""
   mike retitle --message "Remove latest from title of ${PREV_LATEST}" "${PREV_LATEST}" "${PREV_LATEST}"
 fi
-echo "mike deploy --update-aliases --title \"${NEW_VERSION} (latest)\" \"${NEW_VERSION}\" \"latest\""
-mike deploy --update-aliases --title "${NEW_VERSION} (latest)" "${NEW_VERSION}" "latest"
+
+if [[ "${IS_PRERELEASE}" == "true" ]]; then
+  echo "Pre-release version. This release will NOT be given the \"latest\" alias."
+  echo "mike deploy --title \"${NEW_VERSION}\" \"${NEW_VERSION}\""
+  mike deploy --title "${NEW_VERSION}" "${NEW_VERSION}"
+else
+  echo "mike deploy --update-aliases --title \"${NEW_VERSION} (latest)\" \"${NEW_VERSION}\" \"latest\""
+  mike deploy --update-aliases --title "${NEW_VERSION} (latest)" "${NEW_VERSION}" "latest"
+fi


### PR DESCRIPTION
#119 Gave us the functionality to mark the Github release as a per-release based on the version being bumped. However, documentation publishing would always mark the new version as being the latest release. This change will allow "latest" to point to `X.Y.Z` when `X.Y.Z+1.alpha` is published.

Example of the code working:
* [Pipeline that publishes the docs](https://github.com/plannigan/actions-playground/runs/3636073890?check_suite_focus=true)
* [latest docs page](https://plannigan.github.io/actions-playground/latest/) Note that it does not point to `0.12.0.alpha`. (It points to `0.12.0.dev` because I hadn't copied over the code to publish as a per-release when I first tested the changes.)


Closes #121