### PR TITLE
Clean up tool configurations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,32 +1,12 @@
 [tool.black]
 line-length = 88
-target_version = ['py36']
-exclude = '''
-/(
-    venv
-  | \.git
-  | \.hg
-  | \.mypy_cache
-  | \.tox
-  | \.venv
-  | _build
-  | buck-out
-  | build
-  | dist
-
-  # The following are specific to Black, you probably don't want those.
-  | blib2to3
-  | tests/data
-)/
-'''
+target-version = ["py37", "py38", "py39", "py310"]
 
 [tool.mypy]
 ignore_missing_imports = true
 
 [tool.isort]
-line_length=88
-multi_line_output=3
-include_trailing_comma=true
+profile = "black"
 
 [tool.coverage.run]
 branch = true
@@ -41,7 +21,7 @@ exclude_lines = [
 
 [tool.pytest.ini_options]
 addopts = "--verbose --cov=columbo --cov-report xml:/tmp/coverage.xml --cov-report term-missing"
-python_files = "tests/*.py"
+testpaths = ["tests"]
 
 [build-system]
 requires = ["setuptools >= 40.9.0", "wheel"]


### PR DESCRIPTION
- [x] Change `black`'s target python version
- [x] Switch `black` to `extend-exclude`. Most (all?) of the entries are excluded by `black` by default. it is better to only list the things that are specific to the project.
- [x] Change `isort` to use `black` profile. This will simplify the number of settings that need to be specified because `isort` comes with a profile that matches how `black` formats code.
- [x] Use `testpaths` in `pytest` instead the `python_files` setting that only matches files in the tests directory.

Closes #275 