### PR TITLE
Allow docs dependencies to be installed separately

### DIFF
--- a/.github/actions/install-dependencies/action.sh
+++ b/.github/actions/install-dependencies/action.sh
@@ -12,3 +12,8 @@ if [[ "${INSTALL_TEST_REQUIREMENTS}" == "true"  ]]; then
   echo "Installing test requirements"
   pip install -r requirements-test.txt
 fi
+
+if [[ "${INSTALL_DOCS_REQUIREMENTS}" == "true"  ]]; then
+  echo "Installing docs requirements"
+  pip install -r requirements-docs.txt
+fi

--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -9,6 +9,10 @@ inputs:
     description: "Should requirements-test.txt be installed"
     default: "false"
     required: false
+  docs-requirements:
+    description: "Should requirements-docs.txt be installed"
+    default: "false"
+    required: false
 runs:
   using: "composite"
   steps:
@@ -18,3 +22,4 @@ runs:
       env:
         INSTALL_REQUIREMENTS: ${{ inputs.requirements }}
         INSTALL_TEST_REQUIREMENTS: ${{ inputs.test-requirements }}
+        INSTALL_DOCS_REQUIREMENTS: ${{ inputs.docs-requirements }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -176,7 +176,7 @@ jobs:
         uses: ./.github/actions/install-dependencies
         with:
           requirements: "true"
-          test-requirements: "true"
+          docs-requirements: "true"
 
       - name: Build Docs
         run: mkdocs build --strict
@@ -202,7 +202,7 @@ jobs:
         uses: ./.github/actions/install-dependencies
         with:
           requirements: "true"
-          test-requirements: "true"
+          docs-requirements: "true"
 
       - name: Push documentation changes
         uses: ./.github/actions/publish-docs-with-mike

--- a/docker/devbox.dockerfile
+++ b/docker/devbox.dockerfile
@@ -23,6 +23,6 @@ USER ${_USER}
 COPY --chown=${UID}:${GID} ./requirements*.txt /app/
 WORKDIR /app
 
-RUN pip install -r requirements.txt -r requirements-test.txt
+RUN pip install -r requirements.txt -r requirements-test.txt -r requirements-docs.txt
 
 CMD bash

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,7 @@
+mike==1.1.2
+markdown-include==0.6.0
+mkdocs==1.2.3
+mkdocs-material==8.2.5
+mkdocs-minify-plugin==0.5.0
+mkdocs-redirects==1.0.3
+mkdocstrings[python]==0.18.1

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,13 +3,6 @@ black==22.1.0
 bump2version==1.0.1
 flake8==4.0.1
 isort==5.10.1
-mike==1.1.2
-markdown-include==0.6.0
-mkdocs==1.2.3
-mkdocs-material==8.2.5
-mkdocs-minify-plugin==0.5.0
-mkdocs-redirects==1.0.3
-mkdocstrings[python]==0.18.1
 mypy==0.941
 pytest==7.1.1
 pytest-cov==3.0.0


### PR DESCRIPTION
This works around a version incompatibility because flake8 requires and older version of `importlib-metadata` (PyCQA/flake8#1438).