### PR TITLE
Reject default values that do no satisfy the validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `BasicQuestion.ask()` will only evaluate dynamic values for the prompt message and default value once per instead of
+- `BasicQuestion.ask()` will only evaluate dynamic values for the prompt message and default value once instead of
   repeatedly when the response was invalid.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Python version `3.10` tested during CI
 - Python version `3.10` added to package classifiers
 
+### Changed
+
+- `BasicQuestion.ask()` will only evaluate dynamic values for the prompt message and default value once per instead of
+  repeatedly when the response was invalid.
+
+### Fixed
+
+- Prevent infinite loop when the default value for a `BasicQuestion` does not satisfy the `Validator` and `no_user_input`
+  was set to `True`. Now raises a `ValueError` when this situation is detected.
+
+  The intent was that the default value would always satisfy the `Validator`, but that was not enforced or explicitly
+  documented.
+
 ### Removed
 
-* Support for Python version `3.6`.
+- Support for Python version `3.6`.
 
 ## [0.11.0] - 2021-08-04
 

--- a/columbo/_cli.py
+++ b/columbo/_cli.py
@@ -45,7 +45,6 @@ def parse_args(
     :raises CliException: A value passed to CLI argument was not valid and `exit_on_error` was `False`.
     :raises DuplicateQuestionNameException: One of the given questions attempts to reuse a name. This includes a
         question that was used to create `answers` if given.
-    :raises ValueError: A default value was not valid and `no_user_input` is set to `True`.
     """
     validate_duplicate_question_names(interactions, answers)
     parser = create_parser(interactions, parser_name)

--- a/columbo/_cli.py
+++ b/columbo/_cli.py
@@ -45,6 +45,7 @@ def parse_args(
     :raises CliException: A value passed to CLI argument was not valid and `exit_on_error` was `False`.
     :raises DuplicateQuestionNameException: One of the given questions attempts to reuse a name. This includes a
         question that was used to create `answers` if given.
+    :raises ValueError: A default value was not valid and `no_user_input` is set to `True`.
     """
     validate_duplicate_question_names(interactions, answers)
     parser = create_parser(interactions, parser_name)

--- a/columbo/_interaction.py
+++ b/columbo/_interaction.py
@@ -558,7 +558,7 @@ def get_answers(
     :return: Dictionary of answers.
     :raises DuplicateQuestionNameException: One of the given questions attempts to reuse a name. This includes a
         question that was used to create `answers` if given.
-    :raises ValueError: A default value was not valid and `no_user_input` is set to `True`.
+    :raises ValueError: A default value did not satisfy the `Interaction`'s validator.
     """
     validate_duplicate_question_names(interactions, answers)
     result = {} if answers is None else dict(answers)

--- a/docs/usage-guide/interactions.md
+++ b/docs/usage-guide/interactions.md
@@ -40,6 +40,9 @@ In addition to the arguments [mentioned above](#all-questions), `BasicQuestion` 
     providing this argument means that any value provided by the user will be accepted. See
     [Validators][validators] for more details.
 
+  The `default` value for the `BasicQuestion` **must** satisfy the `Validator`. An exception will be raised if that is
+  not the case.
+
 ### Choice
 
 In addition to the arguments [mentioned above](#all-questions), `Choice` also accepts the following argument.

--- a/docs/usage-guide/validators.md
+++ b/docs/usage-guide/validators.md
@@ -4,8 +4,13 @@
 
 `BasicQuestion` allows the user to provide arbitrary text as the answer to the question. However, there are frequently
 constraints on what is considered a valid answer. Providing a `Validator` for the question allows `columbo` to verify
-that the text provided by the user satisfies those constraints. If the answer is not valid, `columbo` will tell the user that
-the answer is not valid and ask them to try again.
+that the text provided by the user satisfies those constraints. If the answer is not valid, `columbo` will tell the user
+that the answer is not valid and ask them to try again.
+
+The `default` value for the `BasicQuestion` **must** satisfy the `Validator`. An exception will be raised if that is not
+the case. This is because it could lead to:
+* An infinite loop when prompting a user
+* Command line parsing always failing if a value is not given
 
 !!! Note Implicit Validators
     While `Choice` and `Confirm` do not expose a `validator` argument they still ensure that the answer is valid.

--- a/tests/interaction_test.py
+++ b/tests/interaction_test.py
@@ -426,6 +426,23 @@ def test_basic_question__invalid_asked_multiple_times(mocker, validity_responses
     assert user_io_ask_mock.call_count == len(validity_responses)
 
 
+@pytest.mark.parametrize("no_user_input", [True, False])
+def test_basic_question__default_invalid_no_user_input__error(no_user_input, mocker):
+    """
+    Default values should be valid answers. However, if not BasicQuestion's retry loop could cause an infinite loop
+    when no_user_input is provided.
+    """
+    user_io = mocker.patch("columbo._interaction.user_io")
+    user_io.ask.return_value = SOME_DEFAULT
+    with pytest.raises(ValueError):
+        BasicQuestion(
+            SOME_NAME,
+            SOME_STRING,
+            SOME_DEFAULT,
+            validator=lambda v, a: ValidationFailure("some error"),
+        ).ask(SOME_ANSWERS, no_user_input=no_user_input)
+
+
 def test_to_value__invalid_type__exception():
     with pytest.raises(ValueError):
         to_value(object(), SOME_ANSWERS, str)


### PR DESCRIPTION
Starts enforcing a previous implied expectation.

The check can't be done when creating the `BasicQuestion` because both the default and the validator may depend on the previous answers, which won't be known until runtime.

Closes #357 