### PR TITLE
Bump version: 0.11.0 → 0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
 ## [0.12.0] - 2022-09-05
 
 ### Changed


### PR DESCRIPTION
Fake version bump PR to re-trigger the pipeline automation. Actual version bump in in #365.