### PR TITLE
feat: Allow `Choice`'s `OptionList` to be a mapping of values → pretty labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added `Options` which supports `Mapping[str, str]` for `Choice` options. This allows users to control
-    how `Choice` options are displayed ([#389](https://github.com/wayfair-incubator/columbo/pull/389))
-
+- Ability for `Choice` to display a custom message instead of the value being selected. This includes a new type alias (`Options`) which supports both the `Mapping[str, str]` and `List[str]` forms. ([#389](https://github.com/wayfair-incubator/columbo/pull/389))
 ### Deprecated
 
 - The `OptionList` type for `Choice` in favor of `Options` ([#389](https://github.com/wayfair-incubator/columbo/pull/389))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added support for `Mapping[str, str]` in `OptionList` which allows users to control
+    how `Choice` options are displayed ([#389](https://github.com/wayfair-incubator/columbo/pull/389))
+
 ### Fixed
 
 - All exceptions raised by `columbo` listed in the docstrings. Improved phrasing to make messaging consistent.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added support for `Mapping[str, str]` in `OptionList` which allows users to control
+- Added `Options` which supports `Mapping[str, str]` for `Choice` options. This allows users to control
     how `Choice` options are displayed ([#389](https://github.com/wayfair-incubator/columbo/pull/389))
+
+### Deprecated
+
+- The `OptionList` type for `Choice` in favor of `Options` ([#389](https://github.com/wayfair-incubator/columbo/pull/389))
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,12 @@ interactions = [
     columbo.Choice(
         "mood",
         "How are you feeling today?",
-        options=["happy", "sad", "sleepy", "confused"],
+        options={
+            "happy": "😀",
+            "sad": "😢",
+            "sleepy": "🥱",
+            "confused": "🤔",
+        },
         default="happy",
     ),
     columbo.Confirm("likes_dogs", "Do you like dogs?", default=True),
@@ -72,10 +77,10 @@ What is your name? [Patrick]:
 What email address should be used to contact Patrick? [me@example.com]: patrick@example.com
 
 How are you feeling today?
-1 - happy
-2 - sad
-3 - sleepy
-4 - confused
+1 - 😀
+2 - 😢
+3 - 🥱
+4 - 🤔
 Enter the number of your choice [1]:
 
 Do you like dogs? (Y/n): y

--- a/columbo/__init__.py
+++ b/columbo/__init__.py
@@ -21,6 +21,7 @@ from columbo._types import (  # noqa: F401
     Answers,
     MutableAnswers,
     OptionList,
+    Options,
     ShouldAsk,
     StaticOrDynamicValue,
     ValidationFailure,

--- a/columbo/_interaction.py
+++ b/columbo/_interaction.py
@@ -9,7 +9,7 @@ from columbo._types import (
     Answer,
     Answers,
     MutableAnswers,
-    OptionList,
+    Options,
     ShouldAsk,
     StaticOrDynamicValue,
     V,
@@ -357,7 +357,7 @@ class Choice(Question):
         self,
         name: str,
         message: StaticOrDynamicValue[str],
-        options: StaticOrDynamicValue[OptionList],
+        options: StaticOrDynamicValue[Options],
         default: StaticOrDynamicValue[str],
         cli_help: Optional[str] = None,
         should_ask: Optional[ShouldAsk] = None,
@@ -401,7 +401,7 @@ class Choice(Question):
         self._value_if_not_asked = value_if_not_asked
 
     @property
-    def options(self) -> StaticOrDynamicValue[OptionList]:
+    def options(self) -> StaticOrDynamicValue[Options]:
         return self._options
 
     @property
@@ -449,7 +449,7 @@ class Choice(Question):
         *,
         name: Possible[str] = _NOT_GIVEN,
         message: Possible[StaticOrDynamicValue[str]] = _NOT_GIVEN,
-        options: Possible[StaticOrDynamicValue[OptionList]] = _NOT_GIVEN,
+        options: Possible[StaticOrDynamicValue[Options]] = _NOT_GIVEN,
         default: Possible[StaticOrDynamicValue[str]] = _NOT_GIVEN,
         cli_help: Possible[Optional[str]] = _NOT_GIVEN,
         should_ask: Possible[Optional[ShouldAsk]] = _NOT_GIVEN,

--- a/columbo/_interaction.py
+++ b/columbo/_interaction.py
@@ -370,7 +370,8 @@ class Choice(Question):
         :param message: The message to be displayed to the user. If the value is callable, the argument passed in will
             be the answers that have been provided this far.
         :param options: The set of possible answers to the question. If the value is callable, the argument passed in
-            will be the answers that have been provided this far.
+            will be the answers that have been provided this far. If the value is a `Mapping`, the values of the mapping
+            will be displayed to the user.
         :param default: The default answer to the question. If the value is callable, the argument passed in will be the
             answers that have been provided this far.
         :param cli_help: Optional help message to be displayed for command line interface.

--- a/columbo/_interaction.py
+++ b/columbo/_interaction.py
@@ -371,7 +371,7 @@ class Choice(Question):
             be the answers that have been provided this far.
         :param options: The set of possible answers to the question. If the value is callable, the argument passed in
             will be the answers that have been provided this far. If the value is a `Mapping`, the values of the mapping
-            will be displayed to the user.
+            will be displayed to the user & the respective key will be the returned value.
         :param default: The default answer to the question. If the value is callable, the argument passed in will be the
             answers that have been provided this far.
         :param cli_help: Optional help message to be displayed for command line interface.

--- a/columbo/_interaction.py
+++ b/columbo/_interaction.py
@@ -421,7 +421,7 @@ class Choice(Question):
         :raises ValueError: The value for `options` did not have the correct type.
         """
         options = to_value(
-            list(get_labeled_options(self._options, answers).keys()), answers, list
+            list(to_labeled_options(self._options, answers).keys()), answers, list
         )
         if value not in options:
             return ValidationFailure(error=f"Chosen value: {value} not in options")
@@ -439,7 +439,7 @@ class Choice(Question):
         """
         return user_io.multiple_choice(
             to_value(self._message, answers, str),
-            get_labeled_options(self._options, answers),
+            to_labeled_options(self._options, answers),
             default=to_value(self._default, answers, str),
             no_user_input=no_user_input,
         )
@@ -642,8 +642,8 @@ def to_value(
     raise ValueError(f"Invalid value: {value}")
 
 
-def get_labeled_options(
-    options: StaticOrDynamicValue[OptionList], answers: Answers
+def to_labeled_options(
+    options: StaticOrDynamicValue[Options], answers: Answers
 ) -> Mapping[str, str]:
     resolved_opts = options(answers) if callable(options) else options
     if isinstance(resolved_opts, list):

--- a/columbo/_interaction.py
+++ b/columbo/_interaction.py
@@ -420,9 +420,7 @@ class Choice(Question):
         :return: A ValidationFailure or ValidationSuccess object.
         :raises ValueError: The value for `options` did not have the correct type.
         """
-        options = to_value(
-            list(to_labeled_options(self._options, answers).keys()), answers, list
-        )
+        options = list(to_labeled_options(self._options, answers).keys())
         if value not in options:
             return ValidationFailure(error=f"Chosen value: {value} not in options")
         return ValidationSuccess()

--- a/columbo/_types.py
+++ b/columbo/_types.py
@@ -24,7 +24,7 @@ class ValidationFailure:
 Answer = Union[bool, str]
 Answers = Mapping[str, Answer]
 MutableAnswers = MutableMapping[str, Answer]
-OptionList = List[str]
+OptionList = Union[List[str], Mapping[str, str]]
 V = TypeVar("V")
 StaticOrDynamicValue = Union[V, Callable[[Answers], V]]
 ShouldAsk = Callable[[Answers], bool]

--- a/columbo/_types.py
+++ b/columbo/_types.py
@@ -24,7 +24,8 @@ class ValidationFailure:
 Answer = Union[bool, str]
 Answers = Mapping[str, Answer]
 MutableAnswers = MutableMapping[str, Answer]
-OptionList = Union[List[str], Mapping[str, str]]
+OptionList = List[str]
+Options = Union[List[str], Mapping[str, str]]
 V = TypeVar("V")
 StaticOrDynamicValue = Union[V, Callable[[Answers], V]]
 ShouldAsk = Callable[[Answers], bool]

--- a/columbo/_user_io.py
+++ b/columbo/_user_io.py
@@ -2,7 +2,7 @@
 Helpful wrappers for prompt-toolkit functionality.
 """
 
-from typing import Collection
+from typing import Mapping
 
 from prompt_toolkit import shortcuts
 from prompt_toolkit.formatted_text import merge_formatted_text
@@ -54,7 +54,7 @@ def ask(question: str, default: str, no_user_input: bool = False, **kwargs) -> s
 
 def multiple_choice(
     question: str,
-    options: Collection[str],
+    options: Mapping[str, str],
     default: str,
     no_user_input: bool = False,
     **kwargs,
@@ -65,10 +65,10 @@ def multiple_choice(
     prompt_lines = [question]
     default_choice = None
     choice_map = {}
-    for i, value in enumerate(options):
+    for i, (value, label) in enumerate(options.items()):
         key = str(i + 1)
         choice_map[key] = value
-        prompt_lines.append(f"{key} - {value}")
+        prompt_lines.append(f"{key} - {label}")
 
         if default == value:
             default_choice = key

--- a/docs/api.md
+++ b/docs/api.md
@@ -11,7 +11,8 @@ library. The following table defines the aliases that are used.
 | `Answers`              | `Mapping[str, Answer]`                         |
 | `Interaction`          | `Union[Echo, Acknowledge, Question]`           |
 | `MutableAnswers`       | `MutableMapping[str, Answer]`                  |
-| `OptionList`           | `List[str]`                                    |
+| `OptionList`†          | `List[str]`                                    |
+| `Options`              | `Union[List[str], Mapping[str, str]]`          |
 | `Possible`*            | `Union[T, Literal[_Sentinel]]`                 |
 | `ShouldAsk`            | `Callable[[Answers], bool]`                    |
 | `StaticOrDynamicValue` | `Union[V, Callable[[Answers], V]]`             |
@@ -19,10 +20,11 @@ library. The following table defines the aliases that are used.
 | `Validator`            | `Callable[[str, Answers], ValidationResponse]` |
 
 !!! note
-    `Possible` is a special construct used in `copy()` methods to indicate that a value was not
+    \* `Possible` is a special construct used in `copy()` methods to indicate that a value was not
     provided. `Possible`, `_Sentinel`, & `_NOT_GIVEN` are not exposed by `columbo`, but are
     documented here for completeness.
-
+    
+    † `OptionList` is deprecated in favor of `Options`. It will be removed in a future release.
 
 ## Interactions
 

--- a/docs/examples/index_user_prompts.py
+++ b/docs/examples/index_user_prompts.py
@@ -16,7 +16,12 @@ interactions = [
     columbo.Choice(
         "mood",
         "How are you feeling today?",
-        options=["happy", "sad", "sleepy", "confused"],
+        options={
+            "happy": "😀",
+            "sad": "😢",
+            "sleepy": "🥱",
+            "confused": "🤔",
+        },
         default="happy",
     ),
     columbo.Confirm("likes_dogs", "Do you like dogs?", default=True),

--- a/docs/index.md
+++ b/docs/index.md
@@ -43,10 +43,10 @@ What is your name? [Patrick]:
 What email address should be used to contact Patrick? [me@example.com]: patrick@example.com
 
 How are you feeling today?
-1 - happy
-2 - sad
-3 - sleepy
-4 - confused
+1 - 😀
+2 - 😢
+3 - 🥱
+4 - 🤔
 Enter the number of your choice [1]:
 
 Do you like dogs? (Y/n): y

--- a/docs/usage-guide/interactions.md
+++ b/docs/usage-guide/interactions.md
@@ -53,7 +53,9 @@ In addition to the arguments [mentioned above](#all-questions), `BasicQuestion` 
 
 In addition to the arguments [mentioned above](#all-questions), `Choice` also accepts the following argument.
 
-* `options`: The list of possible value the user can choose from.
+* `options`: The set of possible values the user can choose from. This can be provided as a list of strings, or as
+    a `Mapping[str, str]` where the mapping's key is what is recorded as the answer, and the mapping's
+    value is what is displayed to the user.
 
 ### Confirm
 

--- a/docs/usage-guide/interactions.md
+++ b/docs/usage-guide/interactions.md
@@ -54,7 +54,7 @@ In addition to the arguments [mentioned above](#all-questions), `BasicQuestion` 
 In addition to the arguments [mentioned above](#all-questions), `Choice` also accepts the following argument.
 
 * `options`: The set of possible values the user can choose from. This can be provided as a list of strings, or as
-    a `Mapping[str, str]` where the mapping's key is what is recorded as the answer, and the mapping's
+    a mapping of string to string where the key is what is recorded as the answer, and the 
     value is what is displayed to the user.
 
 ### Confirm

--- a/tests/interaction_test.py
+++ b/tests/interaction_test.py
@@ -10,7 +10,12 @@ from columbo import (
     ValidationFailure,
     ValidationSuccess,
 )
-from columbo._interaction import canonical_arg_name, get_answers, to_value
+from columbo._interaction import (
+    canonical_arg_name,
+    get_answers,
+    get_labeled_options,
+    to_value,
+)
 from tests.sample_data import (
     DUPLICATE_QUESTION_NAME_PARAMS,
     QUESTION_NAME_STANDARDIZATION_PARAMS,
@@ -487,6 +492,11 @@ def test_basic_question__default_invalid_no_user_input__error(no_user_input, moc
 def test_to_value__invalid_type__exception():
     with pytest.raises(ValueError):
         to_value(object(), SOME_ANSWERS, str)
+
+
+def test_get_labeled_options__invalid_type__exception():
+    with pytest.raises(ValueError):
+        get_labeled_options(object(), SOME_ANSWERS)
 
 
 @pytest.mark.parametrize(

--- a/tests/interaction_test.py
+++ b/tests/interaction_test.py
@@ -13,7 +13,7 @@ from columbo import (
 from columbo._interaction import (
     canonical_arg_name,
     get_answers,
-    get_labeled_options,
+    to_labeled_options,
     to_value,
 )
 from tests.sample_data import (
@@ -494,9 +494,9 @@ def test_to_value__invalid_type__exception():
         to_value(object(), SOME_ANSWERS, str)
 
 
-def test_get_labeled_options__invalid_type__exception():
+def test_to_labeled_options__invalid_type__exception():
     with pytest.raises(ValueError):
-        get_labeled_options(object(), SOME_ANSWERS)
+        to_labeled_options(object(), SOME_ANSWERS)
 
 
 @pytest.mark.parametrize(

--- a/tests/interaction_test.py
+++ b/tests/interaction_test.py
@@ -18,8 +18,10 @@ from tests.sample_data import (
     SOME_BOOL,
     SOME_DEFAULT,
     SOME_DYNAMIC_DEFAULT_RESULT,
+    SOME_DYNAMIC_MAPPING_OPTION_RESULT,
     SOME_DYNAMIC_OPTION_RESULT,
     SOME_DYNAMIC_STRING_RESULT,
+    SOME_MAPPING_OPTIONS,
     SOME_NAME,
     SOME_OPTIONS,
     SOME_OTHER_BOOL,
@@ -28,6 +30,7 @@ from tests.sample_data import (
     SampleQuestion,
     some_dynamic_bool,
     some_dynamic_default,
+    some_dynamic_mapping_options,
     some_dynamic_options,
     some_dynamic_string,
 )
@@ -131,28 +134,46 @@ def test_choice__no_input__default_value():
     assert result == SOME_DEFAULT
 
 
-def test_choice__static_message__multiple_choice_called(mocker):
+@pytest.mark.parametrize(
+    "options,options_to_mc",
+    [
+        (SOME_OPTIONS, {v: v for v in SOME_OPTIONS}),
+        (SOME_MAPPING_OPTIONS, SOME_MAPPING_OPTIONS),
+    ],
+)
+def test_choice__static_message__multiple_choice_called_with_mapping_of_options(
+    options, options_to_mc, mocker
+):
     user_io = mocker.patch("columbo._interaction.user_io")
 
-    Choice(SOME_NAME, SOME_STRING, SOME_OPTIONS, SOME_DEFAULT).ask(
+    Choice(SOME_NAME, SOME_STRING, options, SOME_DEFAULT).ask(
         SOME_ANSWERS, no_user_input=True
     )
 
     user_io.multiple_choice.assert_called_once_with(
-        SOME_STRING, SOME_OPTIONS, default=SOME_DEFAULT, no_user_input=True
+        SOME_STRING, options_to_mc, default=SOME_DEFAULT, no_user_input=True
     )
 
 
-def test_choice__dynamic_message__multiple_choice_dynamic_message(mocker):
+@pytest.mark.parametrize(
+    "dy_options,dy_options_to_mc",
+    [
+        (some_dynamic_options, {v: v for v in SOME_DYNAMIC_OPTION_RESULT}),
+        (some_dynamic_mapping_options, SOME_DYNAMIC_MAPPING_OPTION_RESULT),
+    ],
+)
+def test_choice__dynamic_message__multiple_choice_dynamic_message(
+    dy_options, dy_options_to_mc, mocker
+):
     user_io = mocker.patch("columbo._interaction.user_io")
 
-    Choice(
-        SOME_NAME, some_dynamic_string, some_dynamic_options, some_dynamic_default
-    ).ask(SOME_ANSWERS, no_user_input=True)
+    Choice(SOME_NAME, some_dynamic_string, dy_options, some_dynamic_default).ask(
+        SOME_ANSWERS, no_user_input=True
+    )
 
     user_io.multiple_choice.assert_called_once_with(
         SOME_DYNAMIC_STRING_RESULT,
-        SOME_DYNAMIC_OPTION_RESULT,
+        dy_options_to_mc,
         default=SOME_DYNAMIC_DEFAULT_RESULT,
         no_user_input=True,
     )
@@ -168,10 +189,16 @@ def test_choice_is_valid__static_options__expected_result(value, is_valid):
 
 
 @pytest.mark.parametrize(
-    "value,is_valid", [(SOME_DYNAMIC_DEFAULT_RESULT, True), (SOME_STRING, False)]
+    "value,is_valid,options",
+    [
+        (SOME_DYNAMIC_DEFAULT_RESULT, True, some_dynamic_options),
+        (SOME_STRING, False, some_dynamic_options),
+        (SOME_DYNAMIC_DEFAULT_RESULT, True, some_dynamic_mapping_options),
+        (SOME_STRING, False, some_dynamic_mapping_options),
+    ],
 )
-def test_choice_is_valid__dynamic_options__expected_result(value, is_valid):
-    question = Choice(SOME_NAME, SOME_STRING, some_dynamic_options, SOME_DEFAULT)
+def test_choice_is_valid__dynamic_options__expected_result(value, is_valid, options):
+    question = Choice(SOME_NAME, SOME_STRING, options, SOME_DEFAULT)
 
     result = question.validate(value, SOME_ANSWERS)
 
@@ -179,10 +206,16 @@ def test_choice_is_valid__dynamic_options__expected_result(value, is_valid):
 
 
 @pytest.mark.parametrize(
-    "value,is_valid", [(SOME_DYNAMIC_DEFAULT_RESULT, True), (SOME_STRING, False)]
+    "value,is_valid,options",
+    [
+        (SOME_DYNAMIC_DEFAULT_RESULT, True, some_dynamic_options),
+        (SOME_STRING, False, some_dynamic_options),
+        (SOME_DYNAMIC_DEFAULT_RESULT, True, some_dynamic_mapping_options),
+        (SOME_STRING, False, some_dynamic_mapping_options),
+    ],
 )
-def test_choice__validate__dynamic_options__expected_result(value, is_valid):
-    question = Choice(SOME_NAME, SOME_STRING, some_dynamic_options, SOME_DEFAULT)
+def test_choice__validate__dynamic_options__expected_result(value, is_valid, options):
+    question = Choice(SOME_NAME, SOME_STRING, options, SOME_DEFAULT)
 
     result = question.validate(value, SOME_ANSWERS)
 
@@ -212,17 +245,24 @@ def test_choice_copy__no_args__multiple_choice_same_message(mocker):
     assert calls[0] == calls[1]
 
 
-def test_choice_copy__diff_message__multiple_choice_diff_message(mocker):
+@pytest.mark.parametrize(
+    "dy_options,dy_options_to_mc,new_options",
+    [
+        (some_dynamic_options, {v: v for v in SOME_OPTIONS}, SOME_OPTIONS),
+        (some_dynamic_mapping_options, SOME_MAPPING_OPTIONS, SOME_MAPPING_OPTIONS),
+    ],
+)
+def test_choice_copy__diff_message__multiple_choice_diff_message(
+    dy_options, dy_options_to_mc, new_options, mocker
+):
     user_io = mocker.patch("columbo._interaction.user_io")
 
-    Choice(
-        SOME_NAME, some_dynamic_string, some_dynamic_options, some_dynamic_default
-    ).copy(message=SOME_STRING, options=SOME_OPTIONS, default=SOME_DEFAULT).ask(
-        SOME_ANSWERS, no_user_input=True
-    )
+    Choice(SOME_NAME, some_dynamic_string, dy_options, some_dynamic_default).copy(
+        message=SOME_STRING, options=new_options, default=SOME_DEFAULT
+    ).ask(SOME_ANSWERS, no_user_input=True)
 
     user_io.multiple_choice.assert_called_once_with(
-        SOME_STRING, SOME_OPTIONS, default=SOME_DEFAULT, no_user_input=True
+        SOME_STRING, dy_options_to_mc, default=SOME_DEFAULT, no_user_input=True
     )
 
 

--- a/tests/sample_data.py
+++ b/tests/sample_data.py
@@ -18,6 +18,7 @@ SOME_STRING = "hello"
 SOME_OTHER_STRING = "good-bye"
 SOME_ANSWERS = {"a": "one", "b": "two"}
 SOME_OPTIONS = ["x", "y", "z"]
+SOME_MAPPING_OPTIONS = {"x": "The Letter X", "y": "The Letter Y", "z": "The Letter Z"}
 SOME_DEFAULT = "x"
 SOME_NON_DEFAULT_OPTION = "y"
 SOME_INVALID_OPTION = "NOT_VALID_OPTION"
@@ -32,6 +33,10 @@ def some_dynamic_options(answers):
     return [f"--{x}--" for x in answers.values()]
 
 
+def some_dynamic_mapping_options(answers):
+    return {f"--{x}--": f"~~{x}~~" for x in answers.values()}
+
+
 def some_dynamic_default(answers):
     return f"--{answers['b']}--"
 
@@ -42,6 +47,7 @@ def some_dynamic_bool(_):
 
 SOME_DYNAMIC_STRING_RESULT = "--one--"
 SOME_DYNAMIC_OPTION_RESULT = ["--one--", "--two--"]
+SOME_DYNAMIC_MAPPING_OPTION_RESULT = {"--one--": "~~one~~", "--two--": "~~two~~"}
 SOME_DYNAMIC_DEFAULT_RESULT = "--two--"
 
 SOME_NAMESPACE = Namespace(**{SOME_NAME: SOME_STRING})

--- a/tests/user_io_test.py
+++ b/tests/user_io_test.py
@@ -66,7 +66,7 @@ def test_ask__yes_user_input_no_answer__default_result(mocker):
 def test_multiple_choice__no_user_input__default_value():
     result = user_io.multiple_choice(
         "Some question?",
-        [SOME_STRING, SOME_OTHER_STRING],
+        {SOME_STRING: SOME_STRING, SOME_OTHER_STRING: SOME_OTHER_STRING},
         no_user_input=True,
         default=SOME_OTHER_STRING,
     )
@@ -79,15 +79,39 @@ def test_multiple_choice__yes_user_input__prompt_result_mapped_to_value(mocker):
     mocker.patch("prompt_toolkit.shortcuts.prompt", return_value="2")
 
     result = user_io.multiple_choice(
-        "Some question?", [SOME_STRING, SOME_OTHER_STRING], default=SOME_STRING
+        "Some question?",
+        {
+            SOME_STRING: f"Display Value for {SOME_STRING}",
+            SOME_OTHER_STRING: f"Display Value for {SOME_OTHER_STRING}",
+        },
+        default=SOME_STRING,
     )
 
     assert result == SOME_OTHER_STRING
 
 
+def test_multiple_choice__prompts_with_option_values(mocker):
+    mock_prompt = mocker.patch("prompt_toolkit.shortcuts.prompt", return_value="2")
+
+    _ = user_io.multiple_choice(
+        "Some question?",
+        {
+            f"Key Value for {SOME_STRING}": f"Display Value for {SOME_STRING}",
+            f"Key Value for {SOME_OTHER_STRING}": f"Display Value for {SOME_OTHER_STRING}",
+        },
+        default=f"Key Value for {SOME_STRING}",
+    )
+
+    prompt_text = mock_prompt.call_args[0][0]
+    assert "Display Value for" in prompt_text
+    assert "Key Value for" not in prompt_text
+
+
 def test_multiple_choice__default_not_option__value_error():
     with pytest.raises(ValueError):
-        user_io.multiple_choice("Some question?", ["1", "2", "3"], default="100")
+        user_io.multiple_choice(
+            "Some question?", {"1": "One", "2": "Two", "3": "Three"}, default="100"
+        )
 
 
 def test_multiple_choice__no_options__value_error():


### PR DESCRIPTION
This PR updates the definition of `OptionList` to be _either_ `List[str]` (as is the currently the case) _or_ `Mapping[str, str]`. If a mapping is provided to `Choice` for `options`, the values of the mapping are used as display values when prompting the user. This enhancement allows developers to provide a friendlier user experience while still storing the same answer values as if only a list was provided (current behaviour).

```python
answers = columbo.get_answers(
    [
        columbo.Choice(
            "fav_colour",
            message="What is your favourite colour?",
            options={
                "#FF0000": "Red",
                "#00FF00": "Green",
                "#0000FF": "Blue",
                "#000000": "Black",
            },
            default="#0000FF",
        )
    ]
)

print(answers)
```

Which gives you:

```
What is your favourite colour?
1 - Red
2 - Green
3 - Blue
4 - Black
Enter the number of your choice [3]: 2

{'fav_colour': '#00FF00'}
```


Closes #389