### PR TITLE
Expand files that are considered by Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,6 +15,9 @@
 
    "schedule": [
     "before 4am"
-  ]
-  
+  ],
+
+  "pip_requirements": {
+    "fileMatch": ["(^|/)([\\w-]*)requirements[-\\w]*\\.(txt|pip)$"]
+  }
 }


### PR DESCRIPTION
The default pattern does not match requirements-ABC.txt, only ABC-requierments.txt